### PR TITLE
Husky fix

### DIFF
--- a/client/.husky/pre-commit
+++ b/client/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 # Client linting and type checking
 # cd ./client && pnpm types && pnpm lint --fix && pnpm check-types && git add src/types/generated/
 cd ./client && pnpm lint --fix && pnpm check-types && pnpm test

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "check-types": "tsc",
     "types": "orval --config ./orval.config.ts",
-    "prepare": "cd .. && husky install client/.husky",
+    "prepare": "cd .. && husky client/.husky",
     "test": "jest",
     "test:watch": "jest --watch"
   },


### PR DESCRIPTION
This pull request includes a couple of changes to the client-side configuration and scripts, primarily focusing on the Husky pre-commit hook and the `package.json` file.

### Configuration and Scripts:

* [`client/.husky/pre-commit`](diffhunk://#diff-87fb3b3a5c744718de98df441240af18cf65cffb6284b7d89dafd750eb92b948L1-L3): Removed the Husky script initialization lines to streamline the pre-commit hook.
* [`client/package.json`](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fL12-R12): Modified the `prepare` script to correct the Husky installation command.