### PR TITLE
Chart colors

### DIFF
--- a/client/src/app/local-api/indicators/indicators_v20_02_2025.json
+++ b/client/src/app/local-api/indicators/indicators_v20_02_2025.json
@@ -1469,6 +1469,7 @@
                 "returnGeometry": true,
                 "returnIntersections": true,
                 "outFields": [
+                    "NAME",
                     "NAME as label",
                     ","
                 ]
@@ -1501,7 +1502,7 @@
             "type": "feature",
             "column": [
             ],
-            "layer_id": "0",
+            "layer_id": "3",
             "url": "https://services6.arcgis.com/sROlVM0rATIYgC6a/arcgis/rest/services/Annual_Rainfall_Regimes_Layer/FeatureServer",
             "query_numeric": "",
             "query_table": {
@@ -1509,26 +1510,19 @@
                 "outFields": [
                     "YEARLPP as Precip_mm",
                     "YPPDESCP as Description",
-                    "top as Max_mm",
+                    "top_ as Max_mm",
                     ","
                 ],
                 "returnGeometry": false
             },
             "query_chart": {
                 "where": "1=1",
-                "returnGeometry": false,
-                "groupByFieldsForStatistics": [
-                    "YEARLPP"
-                ],
-                "orderByFields": [
-                    "value DESC"
-                ],
-                "outStatistics": [
-                    {
-                        "onStatisticField": "FID",
-                        "outStatisticFieldName": "value",
-                        "statisticType": "count"
-                    }
+                "returnGeometry": true,
+                "returnIntersections": true,
+                "outFields": [
+                    "YEARLPP as label",
+                    "top_",
+                    ","
                 ]
             }
         }
@@ -1559,7 +1553,7 @@
             "type": "feature",
             "column": [
             ],
-            "layer_id": "0",
+            "layer_id": "4",
             "url": "https://services6.arcgis.com/sROlVM0rATIYgC6a/arcgis/rest/services/Drought_Risk_Layer/FeatureServer",
             "query_numeric": "",
             "query_table": {
@@ -1573,19 +1567,12 @@
             },
             "query_chart": {
                 "where": "1=1",
-                "returnGeometry": false,
-                "groupByFieldsForStatistics": [
-                    "RISKLEV "
-                ],
-                "orderByFields": [
-                    "value DESC"
-                ],
-                "outStatistics": [
-                    {
-                        "onStatisticField": "FID",
-                        "outStatisticFieldName": "value",
-                        "statisticType": "count"
-                    }
+                "returnGeometry": true,
+                "returnIntersections": true,
+                "outFields": [
+                    "RISKLEV",
+                    "RISKLEV as label",
+                    ","
                 ]
             }
         }
@@ -1616,7 +1603,7 @@
             "type": "feature",
             "column": [
             ],
-            "layer_id": "0",
+            "layer_id": "5",
             "url": "https://services6.arcgis.com/sROlVM0rATIYgC6a/arcgis/rest/services/Forest_Fire_Frequency/FeatureServer",
             "query_numeric": "",
             "query_table": {
@@ -1630,19 +1617,12 @@
             },
             "query_chart": {
                 "where": "1=1",
-                "returnGeometry": false,
-                "groupByFieldsForStatistics": [
-                    "firepfreq"
-                ],
-                "orderByFields": [
-                    "value DESC"
-                ],
-                "outStatistics": [
-                    {
-                        "onStatisticField": "FID",
-                        "outStatisticFieldName": "value",
-                        "statisticType": "count"
-                    }
+                "returnGeometry": true,
+                "returnIntersections": true,
+                "outFields": [
+                    "gridcode",
+                    "firepfreq as label",
+                    ","
                 ]
             }
         }

--- a/client/src/app/local-api/indicators/indicators_v20_02_2025.json
+++ b/client/src/app/local-api/indicators/indicators_v20_02_2025.json
@@ -1469,7 +1469,7 @@
                 "returnGeometry": true,
                 "returnIntersections": true,
                 "outFields": [
-                    "CODE as label",
+                    "NAME as label",
                     ","
                 ]
             }

--- a/client/src/containers/indicators/chart/index.tsx
+++ b/client/src/containers/indicators/chart/index.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 
+import Color from "@arcgis/core/Color";
 import { scaleOrdinal } from "@visx/scale";
 import CHROMA from "chroma-js";
 
@@ -29,13 +30,21 @@ export const ChartIndicators = (indicator: ChartIndicatorsProps) => {
   // console.log("LAYER", queryResourceFeatureLayer.data);
 
   const COLOR_SCALE = useMemo(() => {
+    const range =
+      query.data?.features?.map((d) => {
+        const uniqueValue: __esri.UniqueValueInfo =
+          queryResourceFeatureLayer.data?.drawingInfo?.renderer?.uniqueValueInfos?.find(
+            (u: __esri.UniqueValueInfo) => u.value === d.attributes.label,
+          );
+        const c = new Color(uniqueValue?.symbol.color);
+        return c.toHex() ?? "#009ADE";
+      }) ?? [];
+
     return scaleOrdinal({
-      domain: query.data?.features?.map((d) => d.attributes) ?? [],
-      range: CHROMA.scale(["#009ADE", "#93CAEB", "#DBEDF8"]).colors(
-        query.data?.features?.length || 1,
-      ),
+      domain: query.data?.features?.map((d) => d.attributes.label) ?? [],
+      range: range.length ? range : CHROMA.scale("Spectral").colors(10),
     });
-  }, [query.data]);
+  }, [query.data, queryResourceFeatureLayer.data]);
 
   const TOTAL = useMemo(() => {
     if (!query.data) return 0;


### PR DESCRIPTION
This pull request includes several updates to the `indicators_v20_02_2025.json` file and enhancements to the `ChartIndicators` component in `index.tsx`. The changes mainly focus on updating the query configurations and improving the color scaling logic.

### Updates to `indicators_v20_02_2025.json`:

* Changed the `outFields` and `layer_id` in multiple query configurations to reflect updated field names and layer IDs. [[1]](diffhunk://#diff-be47f79de05a59b5ee1f5f0f36ed7e765d9b97d10c1e12464f06caf6398ca719L1472-R1473) [[2]](diffhunk://#diff-be47f79de05a59b5ee1f5f0f36ed7e765d9b97d10c1e12464f06caf6398ca719L1504-R1525) [[3]](diffhunk://#diff-be47f79de05a59b5ee1f5f0f36ed7e765d9b97d10c1e12464f06caf6398ca719L1562-R1556) [[4]](diffhunk://#diff-be47f79de05a59b5ee1f5f0f36ed7e765d9b97d10c1e12464f06caf6398ca719L1576-R1575) [[5]](diffhunk://#diff-be47f79de05a59b5ee1f5f0f36ed7e765d9b97d10c1e12464f06caf6398ca719L1619-R1606)
* Added `returnGeometry` and `returnIntersections` to several query configurations to enhance the returned data. [[1]](diffhunk://#diff-be47f79de05a59b5ee1f5f0f36ed7e765d9b97d10c1e12464f06caf6398ca719L1504-R1525) [[2]](diffhunk://#diff-be47f79de05a59b5ee1f5f0f36ed7e765d9b97d10c1e12464f06caf6398ca719L1576-R1575) [[3]](diffhunk://#diff-be47f79de05a59b5ee1f5f0f36ed7e765d9b97d10c1e12464f06caf6398ca719L1633-R1625)

### Enhancements to `ChartIndicators` component:

* Imported `Color` from `@arcgis/core/Color` to handle color conversion.
* Updated the `COLOR_SCALE` logic to dynamically generate color scales based on the renderer type (`simple`, `uniqueValue`, `classBreaks`). This ensures accurate color representation for different data features.