### PR TITLE
reset topics

### DIFF
--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -19,6 +19,7 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2",
+        xs: "h-5 px-2.5 rounded-lg text-xs",
         sm: "h-8 rounded-md px-3 text-xs",
         lg: "h-10 rounded-md px-8",
         icon: "h-9 w-9",

--- a/client/src/containers/report/indicators/sidebar/topics/counter-indicators-pill.tsx
+++ b/client/src/containers/report/indicators/sidebar/topics/counter-indicators-pill.tsx
@@ -10,7 +10,7 @@ export function CounterIndicatorsPill({ id }: { id: Topic["id"] }) {
   if (!t || !t.indicators || !t.indicators?.length) return null;
 
   return (
-    <span className="rounded-full border border-border bg-secondary px-2.5 py-0.5 text-xs font-semibold text-primary">
+    <span className="rounded-full bg-secondary px-2.5 py-0.5 text-xs font-semibold text-primary">
       {t.indicators.length}
     </span>
   );


### PR DESCRIPTION
This pull request includes several changes to the UI components and the logic for handling topics and indicators in the report sidebar. The most important changes include adding a new button size variant, updating the CounterIndicatorsPill component, and enhancing the TopicItem component with additional functionality and refactoring.

### UI Component Updates:

* [`client/src/components/ui/button.tsx`](diffhunk://#diff-850d23676d29d6ce6945671c961e3cfaec1c7e37cb8e8649d0ce19a3e50b6c18R22): Added a new `xs` size variant to the button component, providing a smaller button option with specific height, padding, and text size.

### CounterIndicatorsPill Component:

* [`client/src/containers/report/indicators/sidebar/topics/counter-indicators-pill.tsx`](diffhunk://#diff-8cab35cdcdea89f338eb2831faece35e31e3995d732a44eb3b192f78dcc9ca41L13-R13): Removed the border from the CounterIndicatorsPill component for a cleaner appearance.

### TopicItem Component Enhancements:

* [`client/src/containers/report/indicators/sidebar/topics/item.tsx`](diffhunk://#diff-7ffdb234ea383df79af988b239c8723582f1397cb6d97643b4369fe969765da9L3-R39): Imported additional dependencies, including `MouseEvent`, `useGetTopicsId`, `IndicatorView`, and `Button`. Added a new utility function `areArraysEqual` to compare arrays of indicators.
* [`client/src/containers/report/indicators/sidebar/topics/item.tsx`](diffhunk://#diff-7ffdb234ea383df79af988b239c8723582f1397cb6d97643b4369fe969765da9L53-R103): Refactored the `handleResetTopic` function to use a more concise and readable approach for resetting topic indicators.
* [`client/src/containers/report/indicators/sidebar/topics/item.tsx`](diffhunk://#diff-7ffdb234ea383df79af988b239c8723582f1397cb6d97643b4369fe969765da9R127-R202): Enhanced the CollapsibleTrigger to handle click events more effectively and added conditional rendering for the CounterIndicatorsPill and Reset button based on the topic's state.