### PR TITLE
ranking order inverted

### DIFF
--- a/client/src/app/parsers.ts
+++ b/client/src/app/parsers.ts
@@ -41,6 +41,6 @@ export const gridFiltersSetUpParser = parseAsJson<{
   limit: number;
   opacity: number;
   direction: "asc" | "desc";
-}>().withDefault({ limit: 10, opacity: 100, direction: "asc" });
+}>().withDefault({ limit: 10, opacity: 100, direction: "desc" });
 export const gridDatasetsParser = parseAsArrayOf(parseAsString).withDefault([]);
 export const gridDatasetSelectedParser = parseAsString;

--- a/client/src/components/map/tooltip.tsx
+++ b/client/src/components/map/tooltip.tsx
@@ -35,7 +35,7 @@ export const Tooltip = () => {
 
     const screenPoint = view.toScreen(point);
 
-    setPosition({ x: screenPoint.x, y: screenPoint.y });
+    setPosition({ x: screenPoint?.x, y: screenPoint?.y });
   }, [cell, view]);
 
   if (!position || typeof cell.id !== "number") return null;

--- a/client/src/containers/report/location/grid/table/setup/index.tsx
+++ b/client/src/containers/report/location/grid/table/setup/index.tsx
@@ -39,7 +39,7 @@ export default function GridTableSetup() {
   const [gridDatasets, setGridDatasets] = useSyncGridDatasets();
   const [gridFilters] = useSyncGridFilters();
   const [, setGridFiltersSetUp] = useSyncGridFiltersSetUp();
-  const [selectedDirection, setDirection] = useState<"asc" | "desc">("asc");
+  const [selectedDirection, setDirection] = useState<"asc" | "desc">("desc");
   const [selectedDataset, setDataset] = useState<string>(gridDatasets[0]);
   const [selectedLimit, setSelectedLimit] = useState<number>();
 


### PR DESCRIPTION
This pull request includes several changes to ensure consistency in the default sorting direction across various components and to add null safety when setting tooltip positions.

Changes to default sorting direction:

* [`client/src/app/parsers.ts`](diffhunk://#diff-9fa64bf6fbe3767ffd383a55f6cf466f2df6325bcfc377655dcc938300c9d496L44-R44): Updated the default sorting direction in `gridFiltersSetUpParser` from "asc" to "desc".
* [`client/src/containers/report/location/grid/table/index.tsx`](diffhunk://#diff-3db71078e6a17e8827ec6a1fa728dde3c9cbdefefebe78e2554bcb980cdf1825L69-R69): Changed the default direction for grid table setup to "desc".
* [`client/src/containers/report/location/grid/table/setup/index.tsx`](diffhunk://#diff-b0a8b637d2d2b3fcbe9997b2f6dd9505e2d95e9c0f19fb60d941cda5229f70daL42-R42): Modified the initial state of `selectedDirection` to "desc".

Enhancements to tooltip positioning:

* [`client/src/components/map/tooltip.tsx`](diffhunk://#diff-89f3b13617fcf4110a90fa03b89922a72247c92d4f198824bd99526a46c86c96L38-R38): Added null safety checks when setting the tooltip position.

Link to task: [AM-284](https://vizzuality.atlassian.net/browse/AM-284?atlOrigin=eyJpIjoiZDkyMzYzODBmMjQwNDJjM2FmOTRiODdmNjk5MzZhOTUiLCJwIjoiaiJ9)

[AM-284]: https://vizzuality.atlassian.net/browse/AM-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ