### PR TITLE
Legends: feature layers

### DIFF
--- a/client/src/components/map/legend/index.tsx
+++ b/client/src/components/map/legend/index.tsx
@@ -10,7 +10,7 @@ export default function Legend({ children }: PropsWithChildren) {
     <Collapsible
       open={open}
       onOpenChange={setOpen}
-      className="rounded-3xl border border-blue-100 bg-white px-4 py-2"
+      className="rounded-lg border border-blue-100 bg-white px-4 py-2"
     >
       <CollapsibleTrigger className="flex w-full min-w-28 items-center justify-between text-sm">
         <span>Legend</span>

--- a/client/src/containers/indicators/map/index.tsx
+++ b/client/src/containers/indicators/map/index.tsx
@@ -12,12 +12,12 @@ import { Indicator } from "@/app/local-api/indicators/route";
 import { CardLoader } from "@/containers/card";
 import WidgetMap from "@/containers/widgets/map";
 
-export const MapIndicators = ({
-  id,
-  resource,
-}: Omit<Indicator, "resource"> & {
-  resource: ResourceFeature | ResourceWebTile | ResourceImageryTile;
-}) => {
+export const MapIndicators = (
+  indicator: Omit<Indicator, "resource"> & {
+    resource: ResourceFeature | ResourceWebTile | ResourceImageryTile;
+  },
+) => {
+  const { id, resource } = indicator;
   const query = useResourceId({ resource });
 
   const LAYER: Partial<__esri.Layer> = useMemo(() => {
@@ -46,7 +46,7 @@ export const MapIndicators = ({
 
   return (
     <CardLoader query={[query]} className="min-h-72 grow">
-      <WidgetMap layers={[LAYER]} />
+      <WidgetMap indicator={indicator} layers={[LAYER]} />
     </CardLoader>
   );
 };

--- a/client/src/containers/widgets/map/index.tsx
+++ b/client/src/containers/widgets/map/index.tsx
@@ -6,9 +6,11 @@ import dynamic from "next/dynamic";
 
 import { useLocationGeometry } from "@/lib/location";
 
+import { Indicator, ResourceFeature } from "@/app/local-api/indicators/route";
 import { useSyncLocation } from "@/app/store";
 
 import SelectedLayer from "@/containers/report/map/layer-manager/selected-layer";
+import { WidgetLegend } from "@/containers/widgets/map/legend";
 
 import Controls from "@/components/map/controls";
 import FullscreenControl from "@/components/map/controls/fullscreen";
@@ -18,10 +20,11 @@ const Map = dynamic(() => import("@/components/map"), { ssr: false });
 const Layer = dynamic(() => import("@/components/map/layers"), { ssr: false });
 
 interface WidgetMapProps extends __esri.MapViewProperties {
+  indicator: Indicator;
   layers: Partial<__esri.Layer>[];
 }
 
-export default function WidgetMap({ layers, ...viewProps }: WidgetMapProps) {
+export default function WidgetMap({ indicator, layers, ...viewProps }: WidgetMapProps) {
   const [location] = useSyncLocation();
   const GEOMETRY = useLocationGeometry(location);
 
@@ -82,13 +85,13 @@ export default function WidgetMap({ layers, ...viewProps }: WidgetMapProps) {
 
         <Layer layer={LABELS_LAYER} index={layers.length + 2} />
 
-        {/* {!!legend && (
-          <div className="absolute bottom-4 left-4 z-10">
-            <Legend>
-              <LegendItem {...legend} direction="vertical" />
-            </Legend>
-          </div>
-        )} */}
+        {indicator.resource.type === "feature" && (
+          <WidgetLegend
+            {...(indicator as Omit<Indicator, "resource"> & {
+              resource: ResourceFeature;
+            })}
+          />
+        )}
 
         <Controls>
           <FullscreenControl />

--- a/client/src/containers/widgets/map/legend/index.tsx
+++ b/client/src/containers/widgets/map/legend/index.tsx
@@ -1,3 +1,88 @@
-export const WidgetLegend = () => {
+import { useMemo } from "react";
+
+import Color from "@arcgis/core/Color";
+
+import { useResourceFeatureLayerId } from "@/lib/indicators";
+
+import { Indicator, ResourceFeature } from "@/app/local-api/indicators/route";
+
+import Legend from "@/components/map/legend";
+import LegendItem, { LegendItemProps } from "@/components/map/legend/item";
+
+export interface WidgetLegendProps {
+  indicator: Indicator;
+}
+
+export const WidgetLegend = ({
+  name_en,
+  resource,
+}: Omit<Indicator, "resource"> & {
+  resource: ResourceFeature;
+}) => {
+  const { data: layerData, isFetched, isFetching } = useResourceFeatureLayerId({ resource });
+
+  const LEGEND = useMemo<LegendItemProps | null>(() => {
+    if (!layerData) return null;
+
+    const renderer = layerData?.drawingInfo?.renderer;
+
+    if (renderer?.type === "simple") {
+      const r = renderer as __esri.SimpleRenderer;
+
+      if (!r.symbol) return null;
+
+      if (!("color" in r.symbol)) return null;
+
+      return {
+        type: "basic",
+        items: [
+          {
+            id: "1",
+            color: new Color(r.symbol.color).toHex(),
+            label: name_en,
+          },
+        ],
+      };
+    }
+
+    if (renderer?.type === "uniqueValue") {
+      const r = renderer as __esri.UniqueValueRenderer;
+
+      return {
+        type: "basic",
+        items: r.uniqueValueInfos?.map((u) => ({
+          id: u.value,
+          color: new Color(u.symbol.color).toHex(),
+          label: `${u.value}`,
+        })),
+      };
+    }
+
+    if (renderer?.type === "classBreaks") {
+      const r = renderer as __esri.ClassBreaksRenderer;
+
+      return {
+        type: "basic",
+        items: r.classBreakInfos?.map((c) => ({
+          id: c.label,
+          color: new Color(c.symbol.color).toHex(),
+          label: `${c.label}`,
+        })),
+      };
+    }
+
+    return null;
+  }, [name_en, layerData]);
+
+  if (!LEGEND || !isFetched || isFetching) return null;
+
+  return (
+    <div className="absolute bottom-4 left-4 z-10 duration-700 animate-in fade-in-0">
+      <Legend>
+        <LegendItem {...LEGEND} direction="vertical" />
+      </Legend>
+    </div>
+  );
+
   return "Legend";
 };


### PR DESCRIPTION
This pull request includes several changes to the `client/src/containers/indicators/map` and `client/src/containers/widgets/map` components to improve the handling and display of map indicators and their legends. The most important changes include refactoring the `MapIndicators` component, updating the `WidgetMap` component to accept an `indicator` prop, and implementing a new `WidgetLegend` component.

Refactoring and improvements to `MapIndicators`:

* [`client/src/containers/indicators/map/index.tsx`](diffhunk://#diff-99b803f880f19cb144a59cbe2d299d5ffe22c89a3e12a4d31b70ab5fba03245fL15-R20): Refactored the `MapIndicators` component to accept an `indicator` object instead of individual props, and updated the `WidgetMap` component to pass the `indicator` prop. [[1]](diffhunk://#diff-99b803f880f19cb144a59cbe2d299d5ffe22c89a3e12a4d31b70ab5fba03245fL15-R20) [[2]](diffhunk://#diff-99b803f880f19cb144a59cbe2d299d5ffe22c89a3e12a4d31b70ab5fba03245fL49-R49)

Enhancements to `WidgetMap`:

* [`client/src/containers/widgets/map/index.tsx`](diffhunk://#diff-5b87dcc63bea91830f38ceb203fcca32f1aad25f489461eaa122bc1cd4220e36R9-R13): Updated the `WidgetMap` component to accept an `indicator` prop and conditionally render the `WidgetLegend` component based on the `indicator.resource.type`. [[1]](diffhunk://#diff-5b87dcc63bea91830f38ceb203fcca32f1aad25f489461eaa122bc1cd4220e36R9-R13) [[2]](diffhunk://#diff-5b87dcc63bea91830f38ceb203fcca32f1aad25f489461eaa122bc1cd4220e36R23-R27) [[3]](diffhunk://#diff-5b87dcc63bea91830f38ceb203fcca32f1aad25f489461eaa122bc1cd4220e36L85-R94)

Introduction of `WidgetLegend`:

* [`client/src/containers/widgets/map/legend/index.tsx`](diffhunk://#diff-5c112b9f6aa26eb20ef7b62c8d8d35c64e6682b81c927b8cc869ba9397885665L1-R86): Added a new `WidgetLegend` component that dynamically generates a legend based on the `indicator`'s resource type and renderer information.