### PR TITLE
report styles

### DIFF
--- a/client/src/app/local-api/indicators/route.ts
+++ b/client/src/app/local-api/indicators/route.ts
@@ -5,7 +5,7 @@ import { IndicatorView } from "@/app/parsers";
 
 import INDICATORS from "./indicators.json";
 
-export type VisualizationType = "map" | "table" | "chart" | "numeric";
+export type VisualizationTypes = "map" | "table" | "chart" | "numeric";
 
 export type ResourceFeature = {
   name: string;
@@ -59,7 +59,7 @@ export type Indicator = {
   unit_en: string;
   unit_pt: string;
   topic: Topic;
-  visualization_types: VisualizationType[];
+  visualization_types: VisualizationTypes[];
   resource:
     | ResourceFeature
     | ResourceWebTile
@@ -90,7 +90,7 @@ export type IndicatorOverview = {
   unit_en: string;
   unit_pt: string;
   topic: number;
-  visualization_types: VisualizationType[];
+  visualization_types: VisualizationTypes[];
   resource: ResourceFeature | ResourceWebTile | ResourceImageryTile;
 };
 

--- a/client/src/app/parsers.ts
+++ b/client/src/app/parsers.ts
@@ -1,10 +1,10 @@
 import { parseAsArrayOf, parseAsFloat, parseAsJson, parseAsString } from "nuqs";
 
-import { VisualizationType } from "./local-api/indicators/route";
+import { VisualizationTypes } from "./local-api/indicators/route";
 
 export type IndicatorView = {
   id: number;
-  type: VisualizationType;
+  type: VisualizationTypes;
   w?: number;
   h?: number;
   x?: number;

--- a/client/src/components/ui/badge.tsx
+++ b/client/src/components/ui/badge.tsx
@@ -11,8 +11,7 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
-        secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        secondary: "border-transparent bg-secondary text-secondary-foreground hover:bg-blue-100",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
         outline: "text-foreground",

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
         destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
         outline: "border border-input shadow-sm hover:bg-primary/20 hover:text-accent-foreground",
-        secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-blue-100",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },

--- a/client/src/constants/datasets.ts
+++ b/client/src/constants/datasets.ts
@@ -12,7 +12,7 @@ import { env } from "@/env.mjs";
 import { convertHexToRgbaArray, getKeys } from "@/lib/utils";
 
 import {
-  BIOMES,
+  // BIOMES,
   CLIMATE_TYPES,
   DEPRIVATION_INDEX,
   ELEVATION_RANGES,
@@ -20,7 +20,7 @@ import {
   FIRES,
   FIRES_COLORMAP,
   INDIGENOUS_LANDS,
-  LAND_COVER,
+  // LAND_COVER,
   // LAND_COVER_COLORMAP,
   POPULATION,
   PROTECTED_AREAS,
@@ -305,16 +305,7 @@ export const DATASETS = {
         content: [],
       }),
     } satisfies FeatureLayer,
-    legend: {
-      type: "basic" as const,
-      items: getKeys(CLIMATE_TYPES)
-        .toSorted((a, b) => CLIMATE_TYPES[a].label.localeCompare(CLIMATE_TYPES[b].label))
-        .map((k) => ({
-          id: k,
-          label: CLIMATE_TYPES[k].label,
-          color: CLIMATE_TYPES[k].color,
-        })),
-    },
+    legend: null,
     metadata: {
       type: "arcgis",
       url: "https://services6.arcgis.com/sROlVM0rATIYgC6a/ArcGIS/rest/services/AFP_Tipos_climaticos_KOEPEN/FeatureServer/info/metadata",
@@ -334,41 +325,32 @@ export const DATASETS = {
       type: "feature",
       url: "https://services6.arcgis.com/sROlVM0rATIYgC6a/arcgis/rest/services/AFP_Biomas/FeatureServer/0",
       maxScale: 0,
-      renderer: new UniqueValueRenderer({
-        field: "BIOME",
-        defaultSymbol: new SimpleFillSymbol({
-          color: [227, 139, 79, 0.8],
-          outline: {
-            color: [230, 230, 230, 0.8],
-            width: 1,
-          },
-        }),
-        uniqueValueInfos: getKeys(BIOMES).map((k) => ({
-          value: k,
-          symbol: new SimpleFillSymbol({
-            color: BIOMES[k].color,
-            outline: {
-              color: [0, 0, 0, 0.25],
-              width: 0.5,
-            },
-          }),
-        })),
-      }),
+      // renderer: new UniqueValueRenderer({
+      //   field: "BIOME",
+      //   defaultSymbol: new SimpleFillSymbol({
+      //     color: [227, 139, 79, 0.8],
+      //     outline: {
+      //       color: [230, 230, 230, 0.8],
+      //       width: 1,
+      //     },
+      //   }),
+      //   uniqueValueInfos: getKeys(BIOMES).map((k) => ({
+      //     value: k,
+      //     symbol: new SimpleFillSymbol({
+      //       color: BIOMES[k].color,
+      //       outline: {
+      //         color: [0, 0, 0, 0.25],
+      //         width: 0.5,
+      //       },
+      //     }),
+      //   })),
+      // }),
       popupEnabled: true,
       popupTemplate: new PopupTemplate({
         title: "{BIOMADES}",
       }),
     } satisfies FeatureLayer,
-    legend: {
-      type: "basic" as const,
-      items: getKeys(BIOMES)
-        .toSorted((a, b) => BIOMES[a].label.localeCompare(BIOMES[b].label))
-        .map((k) => ({
-          id: k,
-          label: BIOMES[k].label,
-          color: BIOMES[k].color,
-        })),
-    },
+    legend: null,
     metadata: {
       type: "arcgis",
       url: "https://services6.arcgis.com/sROlVM0rATIYgC6a/ArcGIS/rest/services/AFP_Biomas/FeatureServer/info/metadata",
@@ -587,16 +569,7 @@ export const DATASETS = {
       title: "Land cover",
       url: "https://iservices6.arcgis.com/sROlVM0rATIYgC6a/arcgis/rest/services/landcover_cog/ImageServer",
     },
-    legend: {
-      type: "basic" as const,
-      items: getKeys(LAND_COVER)
-        .toSorted((a, b) => LAND_COVER[a].label.localeCompare(LAND_COVER[b].label))
-        .map((k) => ({
-          id: k,
-          label: LAND_COVER[k].label,
-          color: LAND_COVER[k].color,
-        })),
-    },
+    legend: null,
     metadata: {
       type: "raster",
       url: null,

--- a/client/src/containers/header/__snapshots__/index.test.tsx.snap
+++ b/client/src/containers/header/__snapshots__/index.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`Header renders the Home link selected 1`] = `
           type="button"
         >
           <div
-            class="inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80"
+            class="inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-secondary text-secondary-foreground hover:bg-blue-100"
           >
             Beta
           </div>
@@ -151,7 +151,7 @@ exports[`Header renders the Hub link selected 1`] = `
           type="button"
         >
           <div
-            class="inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80"
+            class="inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-secondary text-secondary-foreground hover:bg-blue-100"
           >
             Beta
           </div>
@@ -256,7 +256,7 @@ exports[`Header renders the Report Tool link selected 1`] = `
           type="button"
         >
           <div
-            class="inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80"
+            class="inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-secondary text-secondary-foreground hover:bg-blue-100"
           >
             Beta
           </div>

--- a/client/src/containers/indicators/item.tsx
+++ b/client/src/containers/indicators/item.tsx
@@ -48,7 +48,7 @@ export const IndicatorItem = ({ id }: { id: Indicator["id"] }) => {
               </tr>
             )}
             <tr>
-              <td className="w-60">Visualization Types</td>
+              <td className="w-60">Visualization Type</td>
               <td>{(indicator?.visualization_types || [])?.join(", ")}</td>
             </tr>
             {}

--- a/client/src/containers/indicators/resources.tsx
+++ b/client/src/containers/indicators/resources.tsx
@@ -10,7 +10,7 @@ import {
   ResourceFeature,
   ResourceImageryTile,
   ResourceWebTile,
-  VisualizationType,
+  VisualizationTypes,
 } from "@/app/local-api/indicators/route";
 import { useSyncLocation } from "@/app/store";
 
@@ -56,7 +56,7 @@ export const ResourceMap = (
 
 export const ResourceQueryFeature = (
   props: Indicator & {
-    type: VisualizationType;
+    type: VisualizationTypes;
     resource: ResourceFeature;
   },
 ) => {
@@ -100,7 +100,7 @@ export const ResourceQueryFeature = (
 
 export const ResourceQueryImageryTile = (
   props: Indicator & {
-    type: VisualizationType;
+    type: VisualizationTypes;
     resource: ResourceImageryTile;
   },
 ) => {

--- a/client/src/containers/report/indicators/sidebar/topics/indicators/item.tsx
+++ b/client/src/containers/report/indicators/sidebar/topics/indicators/item.tsx
@@ -13,8 +13,9 @@ import { Topic } from "@/app/local-api/topics/route";
 import { useSyncTopics } from "@/app/store";
 
 import Info from "@/containers/info";
-import { VisualizationTypes } from "@/containers/report/indicators/sidebar/topics/indicators/visualization-types";
+import { VisualizationType } from "@/containers/report/indicators/sidebar/topics/indicators/visualization-types";
 
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogClose,
@@ -91,11 +92,18 @@ export function IndicatorsItem({ topic, indicator }: { topic: Topic; indicator: 
           </Tooltip>
 
           <Popover>
-            <PopoverTrigger className="flex h-5 w-5 items-center justify-center rounded-sm bg-secondary">
-              <LuPlus />
+            <PopoverTrigger>
+              <Button
+                aria-label="Visualization type"
+                type="button"
+                variant="secondary"
+                className="h-5 w-5 rounded-sm p-0"
+              >
+                <LuPlus />
+              </Button>
             </PopoverTrigger>
-            <PopoverContent side="left" align="start" className="w-auto bg-background p-2">
-              <VisualizationTypes
+            <PopoverContent side="left" align="start" className="w-auto bg-background p-0">
+              <VisualizationType
                 topicId={topic.id}
                 types={indicator.visualization_types}
                 indicatorId={indicator.id}
@@ -105,7 +113,7 @@ export function IndicatorsItem({ topic, indicator }: { topic: Topic; indicator: 
         </div>
       </div>
 
-      <CollapsibleContent className="flex items-center space-x-2 pl-1 pt-2">
+      <CollapsibleContent className="flex items-center space-x-2 pl-1">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="7"

--- a/client/src/containers/report/indicators/sidebar/topics/indicators/visualization-types.tsx
+++ b/client/src/containers/report/indicators/sidebar/topics/indicators/visualization-types.tsx
@@ -9,24 +9,24 @@ import { useGetTopics } from "@/lib/topics";
 import { cn } from "@/lib/utils";
 
 import { Indicator } from "@/app/local-api/indicators/route";
-import { VisualizationType } from "@/app/local-api/indicators/route";
+import { VisualizationTypes } from "@/app/local-api/indicators/route";
 import { useSyncTopics } from "@/app/store";
 
 import { DEFAULT_VISUALIZATION_SIZES, Topic } from "@/constants/topics";
 
-export function VisualizationTypes({
+export function VisualizationType({
   types = ["map", "table", "chart", "numeric"],
   indicatorId,
   topicId,
 }: {
-  types: VisualizationType[];
+  types: VisualizationTypes[];
   indicatorId: Indicator["id"];
   topicId: Topic["id"];
 }) {
   const [topics, setTopics] = useSyncTopics();
   const { data: topicsData } = useGetTopics();
 
-  const handleVisualizationType = (visualizationType: VisualizationType) => {
+  const handleVisualizationType = (visualizationType: VisualizationTypes) => {
     const widgetSize = DEFAULT_VISUALIZATION_SIZES[visualizationType];
 
     const newIndicator = {
@@ -90,8 +90,10 @@ export function VisualizationTypes({
     numeric: HashIcon,
   };
   return (
-    <>
-      <span className="text-xs font-semibold text-primary">Visualization types</span>
+    <div className="p-1">
+      <span className="px-2 py-1.5 text-xs font-semibold text-muted-foreground/90">
+        Visualization type
+      </span>
       <ul className="flex flex-col">
         {types.map((type) => {
           const isDisabled = !!activeVisualizationsPerIndicatorAndTopic?.find(
@@ -101,11 +103,12 @@ export function VisualizationTypes({
           const Icon = iconComponents[type];
 
           return (
-            <li key={type} className="rounded-[2px] px-1">
+            <li key={type}>
               <button
                 type="button"
                 className={cn({
-                  "flex w-full items-center space-x-2 hover:bg-blue-100": true,
+                  "flex w-full items-center space-x-2 rounded-[2px] px-2 py-1.5 hover:bg-blue-100":
+                    true,
                   "pointer-events-none cursor-none opacity-50": isDisabled,
                 })}
                 disabled={isDisabled}
@@ -115,7 +118,8 @@ export function VisualizationTypes({
 
                 <span
                   className={cn({
-                    "p-1 text-xs font-semibold capitalize text-foreground transition-colors": true,
+                    "text-xs font-semibold capitalize text-foreground transition-colors hover:text-accent-foreground":
+                      true,
                   })}
                 >
                   {type}
@@ -131,6 +135,6 @@ export function VisualizationTypes({
           );
         })}
       </ul>
-    </>
+    </div>
   );
 }

--- a/client/src/containers/results/content/controls/delete.tsx
+++ b/client/src/containers/results/content/controls/delete.tsx
@@ -1,14 +1,14 @@
 import { TooltipPortal } from "@radix-ui/react-tooltip";
 import { Trash2 } from "lucide-react";
 
-import { VisualizationType } from "@/app/local-api/indicators/route";
+import { VisualizationTypes } from "@/app/local-api/indicators/route";
 
 import { Tooltip, TooltipArrow, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 type DeleteHandlerProps = {
   indicatorId: number;
-  type: VisualizationType;
-  onClick: (indicatorId: number, type: VisualizationType) => void;
+  type: VisualizationTypes;
+  onClick: (indicatorId: number, type: VisualizationTypes) => void;
 };
 
 const DeleteHandler = ({ indicatorId, type, onClick }: DeleteHandlerProps) => (

--- a/client/src/containers/results/content/indicator.tsx
+++ b/client/src/containers/results/content/indicator.tsx
@@ -5,7 +5,7 @@ import { createElement, MouseEvent } from "react";
 import { useGetIndicatorsId } from "@/lib/indicators";
 import { cn } from "@/lib/utils";
 
-import { Indicator, VisualizationType } from "@/app/local-api/indicators/route";
+import { Indicator, VisualizationTypes } from "@/app/local-api/indicators/route";
 import {
   ResourceFeature,
   ResourceImageryTile,
@@ -42,7 +42,7 @@ export default function ReportResultsIndicator({
   onEdit,
 }: {
   id: Indicator["id"];
-  type: VisualizationType;
+  type: VisualizationTypes;
   editable: boolean;
   onEdit?: (e: MouseEvent<HTMLElement>) => void;
 }) {

--- a/client/src/containers/results/content/item.tsx
+++ b/client/src/containers/results/content/item.tsx
@@ -7,7 +7,7 @@ import { useAtom } from "jotai";
 
 import { useGetTopicsId } from "@/lib/topics";
 
-import { VisualizationType } from "@/app/local-api/indicators/route";
+import { VisualizationTypes } from "@/app/local-api/indicators/route";
 import { TopicView } from "@/app/parsers";
 import { indicatorsEditionModeAtom, reportEditionModeAtom, useSyncTopics } from "@/app/store";
 
@@ -72,7 +72,7 @@ export const ReportResultsContentItem = ({
   );
 
   const onDeleteIndicator = useCallback(
-    (indicatorId: number, type: VisualizationType) => {
+    (indicatorId: number, type: VisualizationTypes) => {
       setTopics((prev) => {
         if (!prev) return prev;
 

--- a/client/src/lib/indicators.ts
+++ b/client/src/lib/indicators.ts
@@ -11,7 +11,7 @@ import {
   ResourceFeature,
   ResourceImageryTile,
   ResourceWebTile,
-  VisualizationType,
+  VisualizationTypes,
 } from "@/app/local-api/indicators/route";
 import { Topic } from "@/app/local-api/topics/route";
 import TOPICS from "@/app/local-api/topics/topics.json";
@@ -242,7 +242,7 @@ export const useResourceFeatureLayerId = <
  */
 export type QueryFeatureIdParams = {
   id: Indicator["id"];
-  type: VisualizationType;
+  type: VisualizationTypes;
   resource: ResourceFeature;
   geometry: __esri.Polygon | null;
 };
@@ -336,7 +336,7 @@ export const useQueryFeatureId = <
 
 export type QueryImageryTileIdParams = {
   id: Indicator["id"];
-  type: VisualizationType;
+  type: VisualizationTypes;
   resource: ResourceImageryTile;
   geometry: __esri.Polygon | null;
 };


### PR DESCRIPTION
This pull request includes several changes mainly focused on renaming a type and modifying UI components. The most important changes include renaming the `VisualizationType` type to `VisualizationTypes`, updating the UI components to reflect this change, and modifying the styles for secondary buttons and badges.

### Type Renaming:

* [`client/src/app/local-api/indicators/route.ts`](diffhunk://#diff-d2a9525256ffd39462af61838a80c5eae7ea66049780a4ffe96223e0a7b924e6L8-R8): Renamed `VisualizationType` to `VisualizationTypes` and updated all occurrences accordingly. [[1]](diffhunk://#diff-d2a9525256ffd39462af61838a80c5eae7ea66049780a4ffe96223e0a7b924e6L8-R8) [[2]](diffhunk://#diff-d2a9525256ffd39462af61838a80c5eae7ea66049780a4ffe96223e0a7b924e6L62-R62) [[3]](diffhunk://#diff-d2a9525256ffd39462af61838a80c5eae7ea66049780a4ffe96223e0a7b924e6L93-R93)
* [`client/src/app/parsers.ts`](diffhunk://#diff-9fa64bf6fbe3767ffd383a55f6cf466f2df6325bcfc377655dcc938300c9d496L3-R7): Updated import to use `VisualizationTypes` instead of `VisualizationType`.
* [`client/src/containers/indicators/resources.tsx`](diffhunk://#diff-595da05846aef8fd75c529332dfe39cf6fbc6f8dc5e701300f19ff85293c8478L13-R13): Updated the type from `VisualizationType` to `VisualizationTypes` in multiple components. [[1]](diffhunk://#diff-595da05846aef8fd75c529332dfe39cf6fbc6f8dc5e701300f19ff85293c8478L13-R13) [[2]](diffhunk://#diff-595da05846aef8fd75c529332dfe39cf6fbc6f8dc5e701300f19ff85293c8478L59-R59) [[3]](diffhunk://#diff-595da05846aef8fd75c529332dfe39cf6fbc6f8dc5e701300f19ff85293c8478L103-R103)
* [`client/src/containers/results/content/indicator.tsx`](diffhunk://#diff-f3df1e89f4949fffe44b5329f83f134d956d7c20363357c23f25429d3e0d57d6L8-R8): Updated the type from `VisualizationType` to `VisualizationTypes`. [[1]](diffhunk://#diff-f3df1e89f4949fffe44b5329f83f134d956d7c20363357c23f25429d3e0d57d6L8-R8) [[2]](diffhunk://#diff-f3df1e89f4949fffe44b5329f83f134d956d7c20363357c23f25429d3e0d57d6L45-R45)

### UI Component Updates:

* [`client/src/components/ui/badge.tsx`](diffhunk://#diff-f01d021401171f9f7fc4babbdc971876e5db51a1d12aca11739fb1bebca0ce37L14-R14): Changed the hover background color for the secondary variant to `hover:bg-blue-100`.
* [`client/src/components/ui/button.tsx`](diffhunk://#diff-850d23676d29d6ce6945671c961e3cfaec1c7e37cb8e8649d0ce19a3e50b6c18L16-R16): Changed the hover background color for the secondary variant to `hover:bg-blue-100`.
* [`client/src/containers/header/__snapshots__/index.test.tsx.snap`](diffhunk://#diff-ce8a0fd35b4ac36bdecf6a845822d9d6eb46b01fd68bb20a7db26ad0c51fed10L49-R49): Updated the hover background color for the secondary variant in multiple snapshot tests. [[1]](diffhunk://#diff-ce8a0fd35b4ac36bdecf6a845822d9d6eb46b01fd68bb20a7db26ad0c51fed10L49-R49) [[2]](diffhunk://#diff-ce8a0fd35b4ac36bdecf6a845822d9d6eb46b01fd68bb20a7db26ad0c51fed10L154-R154) [[3]](diffhunk://#diff-ce8a0fd35b4ac36bdecf6a845822d9d6eb46b01fd68bb20a7db26ad0c51fed10L259-R259)

### Dataset Modifications:

* [`client/src/constants/datasets.ts`](diffhunk://#diff-4780494477cf134a56714714633f1bdd962c2606ffe371173022b664055056f4L15-R23): Commented out the `BIOMES`, `LAND_COVER`, and their related colormaps, and set the `legend` property to `null` for multiple datasets. [[1]](diffhunk://#diff-4780494477cf134a56714714633f1bdd962c2606ffe371173022b664055056f4L15-R23) [[2]](diffhunk://#diff-4780494477cf134a56714714633f1bdd962c2606ffe371173022b664055056f4L308-R308) [[3]](diffhunk://#diff-4780494477cf134a56714714633f1bdd962c2606ffe371173022b664055056f4L337-R353) [[4]](diffhunk://#diff-4780494477cf134a56714714633f1bdd962c2606ffe371173022b664055056f4L590-R572)

### Minor Text Changes:

* [`client/src/containers/indicators/item.tsx`](diffhunk://#diff-4651912eb8db3e689d77cc0d30c043f162f3d4701a49a5ca7686e3202754accdL51-R51): Changed the label from "Visualization Types" to "Visualization Type".


Link to the task: [AM-249](https://vizzuality.atlassian.net/browse/AM-249?atlOrigin=eyJpIjoiZGFkZDY1MWQzN2Y4NGQzZjk3ZGJhOGE5ZjI0OTk2NjAiLCJwIjoiaiJ9)

[AM-249]: https://vizzuality.atlassian.net/browse/AM-249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ