### PR TITLE
small style fixes, fix clearing indicators

### DIFF
--- a/client/src/app/report/page.tsx
+++ b/client/src/app/report/page.tsx
@@ -18,7 +18,7 @@ export default function ReportPage() {
       <main className="relative flex min-h-[calc(100svh_-_theme(space.20)_+_20px)] flex-col">
         <div className="pointer-events-none absolute bottom-8 left-0 top-10 z-10 w-full">
           <div className="container grid grid-cols-12">
-            <div className="col-span-6 2xl:col-span-4">
+            <div className="col-span-5 2xl:col-span-4">
               <Suspense fallback={null}>
                 <ReportLocation />
               </Suspense>

--- a/client/src/containers/footer/index.tsx
+++ b/client/src/containers/footer/index.tsx
@@ -35,7 +35,7 @@ export default function Footer() {
               Terms & conditions
             </a>
           </Button>
-          <Button variant="link" className="leading-1 text-white">
+          <Button variant="link" className="leading-1 p-0 text-white">
             <a href="https://www.iadb.org/en/home/privacy-notice" target="_blank">
               Privacy Policy
             </a>

--- a/client/src/containers/home/key-features-grid/cards-container.tsx
+++ b/client/src/containers/home/key-features-grid/cards-container.tsx
@@ -45,9 +45,9 @@ export default function CardsContainer() {
       </div>
       <ul
         ref={cardRef}
-        className="mt-6 flex w-full flex-col gap-2 md:mt-20 md:grid md:grid-cols-3 lg:mt-6"
+        className="mt-6 flex w-full flex-col gap-2 md:mt-20 md:grid md:grid-cols-12 lg:mt-6"
       >
-        <li className="flex w-full flex-1 justify-start md:justify-center">
+        <li className="col-span-4 flex w-full flex-1 justify-start md:justify-center">
           <div
             className={`flex flex-1 flex-col items-start justify-start space-y-2 overflow-hidden rounded-sm bg-white p-4 ${
               isCardInView
@@ -59,7 +59,7 @@ export default function CardsContainer() {
             <h4 className="font-bold text-blue-500">Identify hotspots</h4>
           </div>
         </li>
-        <li className="flex w-full flex-1 justify-start md:justify-center">
+        <li className="col-span-4 flex w-full flex-1 justify-start md:justify-center">
           <div
             className={`flex flex-1 flex-col items-start justify-start space-y-2 overflow-hidden rounded-sm bg-white p-4 ${
               isCardInView
@@ -71,7 +71,7 @@ export default function CardsContainer() {
             <h4 className="font-bold text-blue-500">Redefine your area</h4>
           </div>
         </li>
-        <li className="flex w-full flex-1 justify-start md:justify-center">
+        <li className="col-span-4 flex w-full flex-1 justify-start md:justify-center">
           <div
             className={`flex flex-1 flex-col items-start justify-start space-y-2 overflow-hidden rounded-sm bg-white p-4 ${
               isCardInView

--- a/client/src/containers/home/key-features-grid/index.tsx
+++ b/client/src/containers/home/key-features-grid/index.tsx
@@ -9,12 +9,12 @@ import animation from "./grid-animation-lottie.json";
 export default function KeyFeaturesGrid() {
   return (
     <section className="flex bg-blue-50 px-4">
-      <div className="container flex flex-col-reverse items-center justify-center space-x-6 sm:justify-between md:flex-row">
-        <div className="h-full max-w-lg items-center">
+      <div className="container flex flex-col items-center justify-center space-x-6 md:grid md:grid-cols-12">
+        <div className="col-span-12 h-full max-w-lg items-center lg:col-span-6">
           <CardsContainer />
         </div>
-        <div className="m-auto py-10 md:py-28 lg:py-56">
-          <div className="h-80 w-80 sm:h-[400px] sm:w-[400px] md:h-[450px] md:w-[450px] lg:h-[600px] lg:w-[600px] xl:h-[650px] xl:w-[650px]">
+        <div className="col-span-12 m-auto py-10 lg:col-span-6 lg:py-12 xl:py-56">
+          <div className="h-80 w-80 sm:h-[600px] sm:w-[600px] xl:h-[650px] xl:w-[650px]">
             <LazyLottieComponent
               id="grid-animation"
               animationData={animation}

--- a/client/src/containers/home/key-features-report/cards-container.tsx
+++ b/client/src/containers/home/key-features-report/cards-container.tsx
@@ -40,7 +40,7 @@ export default function CardsContainer() {
       </div>
       <ul
         ref={cardRef}
-        className="mt-6 flex flex-col gap-2 md:mt-20 md:grid md:grid-cols-3 lg:mt-6"
+        className="mt-6 flex flex-col gap-2 sm:grid-cols-3 md:mt-20 md:grid lg:mt-6"
       >
         <li className="flex w-full">
           <div

--- a/client/src/containers/home/key-features-report/index.tsx
+++ b/client/src/containers/home/key-features-report/index.tsx
@@ -22,12 +22,12 @@ export default function KeyFeatures() {
       className="container relative grid w-full grid-cols-12 overflow-hidden md:container md:max-h-[720px]"
     >
       {/* Left Section */}
-      <div className="order-2 col-span-12 md:order-1 md:col-span-5">
+      <div className="order-2 col-span-12 md:order-1 md:col-span-6">
         <CardsContainer />
       </div>
 
       {/* Right Section */}
-      <div className="relative order-1 col-span-12 md:order-2 md:col-span-6 md:col-start-7">
+      <div className="relative order-1 col-span-12 md:order-2 md:col-span-5 md:col-start-8">
         {/* Gradients */}
         <Media greaterThanOrEqual="md">
           <>

--- a/client/src/containers/report/indicators/sidebar/clear-indicators.tsx
+++ b/client/src/containers/report/indicators/sidebar/clear-indicators.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
+import { useGetDefaultTopics } from "@/lib/topics";
 import { cn } from "@/lib/utils";
 
 import { useSyncTopics } from "@/app/store";
@@ -7,26 +8,39 @@ import { useSyncTopics } from "@/app/store";
 export default function SidebarClearIndicators() {
   const [topics, setTopics] = useSyncTopics();
 
+  const { data: defaultTopics } = useGetDefaultTopics();
+
+  const defaultIndicators = useMemo(
+    () =>
+      defaultTopics?.map((topic) => ({
+        id: topic.id,
+        indicators: topic?.default_visualization,
+      })),
+    [defaultTopics],
+  );
+
   const indicatorCount =
     topics?.flatMap((topic) => topic.indicators?.map((indicator) => indicator.id))?.length || 0;
 
   const handleClick = useCallback(() => {
-    setTopics([]);
-  }, [setTopics]);
+    if (!!topics?.length) {
+      setTopics([]);
+      return;
+    }
+    if (!!defaultIndicators) setTopics(defaultIndicators);
+  }, [setTopics, topics, defaultIndicators]);
 
   return (
     <button
       type="button"
-      disabled={indicatorCount === 0}
       className={cn({
-        "space-x-1 whitespace-nowrap text-end text-xs font-semibold text-primary transition-colors duration-500 ease-linear":
+        "cursor-pointer space-x-1 whitespace-nowrap text-end text-xs font-semibold text-primary transition-colors duration-500 ease-linear hover:underline":
           true,
-        "cursor-pointer hover:underline": indicatorCount > 0,
       })}
       onClick={handleClick}
     >
-      <span>Clear selection</span>
-      <span>({indicatorCount})</span>
+      <span>{!!topics?.length && topics?.length > 0 ? "Clear all" : "Select all"}</span>
+      {!!topics?.length && <span>({indicatorCount})</span>}
     </button>
   );
 }

--- a/client/src/containers/report/indicators/sidebar/index.tsx
+++ b/client/src/containers/report/indicators/sidebar/index.tsx
@@ -2,17 +2,16 @@
 
 import { useCallback } from "react";
 
-import { ScrollArea } from "@radix-ui/react-scroll-area";
 import { useSetAtom } from "jotai";
 import { LuX } from "react-icons/lu";
 
 import { reportEditionModeAtom } from "@/app/store";
 
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
-  SidebarGroup,
   SidebarHeader,
   useSidebar,
 } from "@/components/ui/sidebar";
@@ -45,14 +44,17 @@ export default function TopicsSidebar() {
           <Search />
         </SidebarHeader>
         <SidebarContent>
-          <ScrollArea className="h-[calc(100vh-245px)]">
-            <div className="flex w-full justify-end">
-              <SidebarClearIndicators />
-            </div>
-            <TopicsList />
-            <SidebarGroup />
-            <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-white to-transparent" />
-          </ScrollArea>
+          <div className="mb-4 flex w-full justify-end pr-2">
+            <SidebarClearIndicators />
+          </div>
+          <div className="relative flex h-full w-full grow">
+            <div className="pointer-events-none absolute left-0 right-0 top-0 z-50 h-2 bg-gradient-to-b from-white to-transparent" />
+
+            <ScrollArea className="h-[calc(100vh-225px)] w-[calc(100%+40px)] overflow-hidden pr-2">
+              <TopicsList />
+              <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-white to-transparent" />
+            </ScrollArea>
+          </div>
         </SidebarContent>
         <SidebarFooter />
       </div>

--- a/client/src/containers/report/indicators/sidebar/topics/index.tsx
+++ b/client/src/containers/report/indicators/sidebar/topics/index.tsx
@@ -56,7 +56,7 @@ export default function TopicsList() {
   );
 
   return (
-    <ul className="flex h-full flex-col gap-2 overflow-y-auto">
+    <ul className="relative flex h-full flex-col gap-2 overflow-y-auto">
       <SortableList onChangeOrder={handleChangeOrder} sortable={{ handle: true, enabled: true }}>
         {ITEMS}
       </SortableList>

--- a/client/src/containers/report/indicators/sidebar/topics/indicators/badges.tsx
+++ b/client/src/containers/report/indicators/sidebar/topics/indicators/badges.tsx
@@ -1,43 +1,49 @@
 "use client";
 
+import { useCallback } from "react";
+
+import { VisualizationTypes } from "@/app/local-api/indicators/route";
 import { useSyncTopics } from "@/app/store";
 
 import { Badge } from "@/components/ui/badge";
 
 export function Badges({ topicId, indicatorId }: { topicId: number; indicatorId: number }) {
-  const [indicators, setIndicators] = useSyncTopics();
+  const [topics, setTopics] = useSyncTopics();
 
-  const topic = indicators?.find(({ id }) => id === topicId);
+  const topic = topics?.find(({ id }) => id === topicId);
   const indicatorsDisplay = topic?.indicators?.filter(({ id }) => indicatorId === id);
 
-  const handleClick = () => {
-    setIndicators((prevIndicators) => {
-      const newIndicators = [...(prevIndicators || [])];
+  const handleDelete = useCallback(
+    (indicatorId: number, type: VisualizationTypes) => {
+      setTopics((prev) => {
+        if (!prev || !topic) return prev;
 
-      const topicIndex = newIndicators.findIndex((topic) => topic.id === topicId);
+        const i = prev?.findIndex((t) => t.id === topic.id);
 
-      if (topicIndex >= 0) {
-        const indicatorsArray = [...(newIndicators[topicIndex].indicators || [])];
+        if (i === -1) return prev;
 
-        const indicatorIndex = indicatorsArray.findIndex(
-          (indicator) => indicator.id === indicatorId,
-        );
+        prev[i] = {
+          id: topic?.id,
+          indicators: prev[i]?.indicators?.filter(
+            (i) => !(i.id === indicatorId && i.type === type),
+          ),
+        };
 
-        if (indicatorIndex >= 0) {
-          indicatorsArray.splice(indicatorIndex, 1);
-        }
-
-        newIndicators[topicIndex].indicators = indicatorsArray;
-      }
-
-      return newIndicators;
-    });
-  };
+        return prev;
+      });
+    },
+    [topic, setTopics],
+  );
 
   return (
     <div className="flex flex-wrap gap-1 py-1.5">
-      {indicatorsDisplay?.map(({ type }) => (
-        <Badge onClick={handleClick} variant="secondary" className="capitalize" key={type}>
+      {indicatorsDisplay?.map(({ id, type }) => (
+        <Badge
+          onClick={() => handleDelete(id, type)}
+          variant="secondary"
+          className="capitalize"
+          key={type}
+        >
           {type}
         </Badge>
       ))}

--- a/client/src/containers/report/indicators/sidebar/topics/indicators/item.tsx
+++ b/client/src/containers/report/indicators/sidebar/topics/indicators/item.tsx
@@ -66,10 +66,8 @@ export function IndicatorsItem({ topic, indicator }: { topic: Topic; indicator: 
           <Tooltip>
             <Dialog>
               <TooltipTrigger asChild>
-                <DialogTrigger asChild>
-                  <button aria-label="Topic info" type="button">
-                    <LuInfo className="h-full w-full shrink-0" />
-                  </button>
+                <DialogTrigger>
+                  <LuInfo className="h-full w-full shrink-0" aria-label="Topic info" />
                 </DialogTrigger>
               </TooltipTrigger>
 
@@ -92,7 +90,7 @@ export function IndicatorsItem({ topic, indicator }: { topic: Topic; indicator: 
           </Tooltip>
 
           <Popover>
-            <PopoverTrigger>
+            <PopoverTrigger asChild>
               <Button
                 aria-label="Visualization type"
                 type="button"


### PR DESCRIPTION
This pull request includes various changes to the `client/src` directory, focusing on layout adjustments, functionality enhancements, and code clean-up. The most important changes are grouped by theme below:

### Layout Adjustments:

* Updated the column span for `ReportLocation` in `ReportPage` to improve layout responsiveness. (`client/src/app/report/page.tsx`)
* Modified the column span and grid layout for elements in `CardsContainer` to enhance the design. (`client/src/containers/home/key-features-grid/cards-container.tsx`) [[1]](diffhunk://#diff-e38e15d160dcc4f6ebc477bd78ffc15f057fefc9c52722576d65c6dd443cc5b2L48-R50) [[2]](diffhunk://#diff-e38e15d160dcc4f6ebc477bd78ffc15f057fefc9c52722576d65c6dd443cc5b2L62-R62) [[3]](diffhunk://#diff-e38e15d160dcc4f6ebc477bd78ffc15f057fefc9c52722576d65c6dd443cc5b2L74-R74)
* Adjusted the grid layout in `KeyFeaturesGrid` to better align elements. (`client/src/containers/home/key-features-grid/index.tsx`)
* Changed the column span in `KeyFeatures` to optimize the layout for different screen sizes. (`client/src/containers/home/key-features-report/index.tsx`)

### Functionality Enhancements:

* Sidebar scrolls
* Added logic to toggle between clearing and selecting all indicators in `SidebarClearIndicators`. (`client/src/containers/report/indicators/sidebar/clear-indicators.tsx`)
* Bug fix in `Badges` to delete indicators. (`client/src/containers/report/indicators/sidebar/topics/indicators/badges.tsx`)

### Code Clean-up:

* Reorganized imports and removed unnecessary components in `TopicsSidebar`. (`client/src/containers/report/indicators/sidebar/index.tsx`) [[1]](diffhunk://#diff-ab53f8b6027af43b081c65bb1fa329f64040edd1dad81c3327f11608b3efc04bL5-L15) [[2]](diffhunk://#diff-ab53f8b6027af43b081c65bb1fa329f64040edd1dad81c3327f11608b3efc04bL48-R57)
* Simplified the button structure in `IndicatorsItem` for better accessibility. (`client/src/containers/report/indicators/sidebar/topics/indicators/item.tsx`) [[1]](diffhunk://#diff-2f07d1170a1b230d34d917d7fd3d83bf7f85355db03c58cd7ca81b681ca1cb0cL69-R70) [[2]](diffhunk://#diff-2f07d1170a1b230d34d917d7fd3d83bf7f85355db03c58cd7ca81b681ca1cb0cL95-R93)