### PR TITLE
Charts: legends

### DIFF
--- a/client/src/components/charts/marimekko.tsx
+++ b/client/src/components/charts/marimekko.tsx
@@ -204,7 +204,7 @@ const MarimekkoChart = <T extends Data>({
         (!isVisible(tooltipData).id || !isVisible(tooltipData).value) && (
           <TooltipInPortal top={tooltipTop} left={tooltipLeft}>
             <div className="flex flex-col space-y-1 text-sm text-blue-900">
-              <p className="font-bold">{tooltipData.data.id}</p>
+              <p className="font-bold">{tooltipData.data.data.label}</p>
               <p>{format(tooltipData)}</p>
             </div>
           </TooltipInPortal>

--- a/client/src/containers/card/index.tsx
+++ b/client/src/containers/card/index.tsx
@@ -19,7 +19,13 @@ import Info from "@/containers/info";
 
 import { Dialog, DialogClose, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Tooltip, TooltipArrow, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipArrow,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface CardProps {
   padding?: boolean;
@@ -48,7 +54,7 @@ export function CardSettings({
   onClick,
 }: PropsWithChildren<{ id: Indicator["id"]; onClick?: (e: MouseEvent<HTMLElement>) => void }>) {
   return (
-    <Tooltip delayDuration={100}>
+    <Tooltip>
       <TooltipTrigger asChild>
         <button
           id={`${id}`}
@@ -71,7 +77,11 @@ export function CardSettings({
 }
 
 export function CardControls({ children }: PropsWithChildren) {
-  return <div className="flex space-x-2">{children}</div>;
+  return (
+    <div className="flex space-x-2">
+      <TooltipProvider delayDuration={500}>{children}</TooltipProvider>
+    </div>
+  );
 }
 
 export function CardInfo({ ids, className }: { ids: Indicator["id"][]; className?: string }) {
@@ -84,7 +94,7 @@ export function CardInfo({ ids, className }: { ids: Indicator["id"][]; className
   if (!description_short_en) return null;
 
   return (
-    <Tooltip delayDuration={100}>
+    <Tooltip>
       <Dialog>
         <TooltipTrigger asChild>
           <DialogTrigger className={cn("flex h-6 w-6 items-center justify-center", className)}>

--- a/client/src/containers/results/content/item.tsx
+++ b/client/src/containers/results/content/item.tsx
@@ -89,12 +89,12 @@ export const ReportResultsContentItem = ({
           <ReportResultsContentIndicatorItem
             topic={topic}
             indicator={{ id, type }}
-            editable={EDITABLE}
+            editable={editable}
           />
         </div>
       );
     });
-  }, [topic, EDITABLE]);
+  }, [topic, editable]);
 
   return (
     <div
@@ -115,7 +115,7 @@ export const ReportResultsContentItem = ({
         containerPadding={[0, 0]}
         isDraggable={EDITABLE}
         isResizable={EDITABLE}
-        resizeHandles={["sw", "nw", "se", "ne"]}
+        resizeHandles={["sw", "se"]}
         resizeHandle={false}
         compactType="vertical"
         onDrop={handleDrop}

--- a/client/src/lib/indicators.ts
+++ b/client/src/lib/indicators.ts
@@ -292,6 +292,21 @@ export const getQueryFeatureId = async ({ type, resource, geometry }: QueryFeatu
           f.setAttribute("total", geometryArea);
         }),
       );
+
+      // Group all results by label
+      const features = fs.features.reduce((acc, curr) => {
+        const index = acc.findIndex((f) => f.attributes.label === curr.attributes.label);
+
+        if (index === -1) {
+          acc.push(curr);
+        } else {
+          acc[index].setAttribute("value", acc[index].attributes.value + curr.attributes.value);
+          acc[index].setAttribute("total", geometryArea);
+        }
+
+        return acc;
+      }, [] as __esri.Graphic[]);
+      fs.features = features;
     }
 
     return fs;

--- a/client/src/lib/indicators.ts
+++ b/client/src/lib/indicators.ts
@@ -298,8 +298,10 @@ export const getQueryFeatureId = async ({ type, resource, geometry }: QueryFeatu
         const index = acc.findIndex((f) => f.attributes.label === curr.attributes.label);
 
         if (index === -1) {
+          // If no feature with the same label exists, add the current feature to the accumulator
           acc.push(curr);
         } else {
+          // If a feature with the same label exists, aggregate the values and update the total
           acc[index].setAttribute("value", acc[index].attributes.value + curr.attributes.value);
           acc[index].setAttribute("total", geometryArea);
         }


### PR DESCRIPTION
This pull request includes updates to the tooltip data display in the Marimekko chart and a new feature grouping mechanism in the `getQueryFeatureId` function. 

Changes to tooltip data display:

* [`client/src/components/charts/marimekko.tsx`](diffhunk://#diff-ba7704e98fa06fbaf0d5ce5c12181c30759d2760f48433660c3f4ec51aa87e12L207-R207): Modified the tooltip to display the `label` from `tooltipData.data.data` instead of `tooltipData.data.id`.

Enhancements to feature grouping:

* [`client/src/lib/indicators.ts`](diffhunk://#diff-ab62245eccaac5179086c6f2b9ad73629f806b5c3661d9cddf294e27b95cee39R295-R309): Added logic to group all results by `label` and aggregate their values in the `getQueryFeatureId` function.