### PR TITLE
Add indications about no data on the prompt

### DIFF
--- a/api/src/app/openai_service.py
+++ b/api/src/app/openai_service.py
@@ -42,6 +42,8 @@ def generate_description(context_data: dict, description_type: str, language: st
             "The description must be engaging, informative, and contextually relevant, "
             "leveraging knowledge of Amazonia’s ecosystem, geography, "
             "and conservation efforts to enrich the narrative."
+            "If no occurrence data is provided for an indicator, just mention that no data is available, "
+            "avoiding empty sentences."
             "Use Markdown formatting for the most critical insights, such as key figures, names, and classifications."
             "Avoid using headers, blockquotes, or introductory phrases."
             "Avoid using using code names like SOL-T-XXX or BR-Lxxx."


### PR DESCRIPTION
This commit just adds extra indications to the AI LLM prompt for the cases where no occurrences are available on the selected area (e.g. no IDB projects in the area).
The extra sentence added is:
`"If no occurrence data is provided for an indicator, just mention that no data is available, avoiding empty sentences."`

And as a result, produces descriptions such as this (in the "Normal" length version")
`"In the selected area of the Amazonia region, the data regarding IDB operations currently lacks specific occurrence information. This indicates that there are no recorded IDB activities or initiatives within the dataset provided for the region. The absence of data might reflect a gap in documentation or possibly a focus on other developmental priorities or areas within the Amazonia.`
 
`Despite the lack of recorded operations, the Amazonia remains a critical region for global ecological balance and biodiversity. The involvement of international bodies like the IDB in such areas typically aims to promote sustainable development, preserve natural resources, and enhance the livelihoods of local communities. Understanding and tracking these operations can offer insights into ongoing conservation efforts and economic development strategies within this vital ecological zone."`