### PR TITLE
fix: sidebar height

### DIFF
--- a/client/src/containers/report/sidebar/indicators/index.tsx
+++ b/client/src/containers/report/sidebar/indicators/index.tsx
@@ -24,7 +24,7 @@ export default function IndicatorsSidebarContent() {
       <div className="relative flex h-full w-full grow">
         <div className="pointer-events-none absolute left-0 right-0 top-0 z-50 h-2 bg-gradient-to-b from-white to-transparent" />
 
-        <ScrollArea className="h-screen max-h-[calc(100vh-148px)] w-[calc(100%+40px)]">
+        <ScrollArea className="h-screen max-h-[calc(100vh-264px)] w-[calc(100%+40px)]">
           <TopicsList />
           <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-white to-transparent" />
         </ScrollArea>


### PR DESCRIPTION
This pull request includes a change to the `IndicatorsSidebarContent` component to adjust the maximum height of the `ScrollArea` in the `client/src/containers/report/sidebar/indicators/index.tsx` file.

* Adjusted the `max-h` value of the `ScrollArea` from `calc(100vh-148px)` to `calc(100vh-264px)` to ensure better layout and scrolling behavior.