### PR TITLE
Ai fixes (AM-331 AM-332 AM-334)

### DIFF
--- a/client/src/app/local-api/indicators/indicators.json
+++ b/client/src/app/local-api/indicators/indicators.json
@@ -2286,8 +2286,12 @@
       },
       "query_ai": {
         "where": "1=1",
-        "outFields": [
-          "*"
+        "outStatistics": [
+          {
+            "onStatisticField": "FID",
+            "outStatisticFieldName": "value",
+            "statisticType": "count"
+          }
         ]
       }
     }

--- a/client/src/app/store.ts
+++ b/client/src/app/store.ts
@@ -118,4 +118,4 @@ export const gridHoverAtom = atom<GridHoverType>({
 
 export const selectedFiltersViewAtom = atom<boolean>(false);
 
-export const isGeneratingAIReportAtom = atom<boolean>(false);
+export const isGeneratingAIReportAtom = atom<Record<string, boolean>>();

--- a/client/src/containers/report/sidebar/ai-content/index.tsx
+++ b/client/src/containers/report/sidebar/ai-content/index.tsx
@@ -46,6 +46,9 @@ export default function AiSidebarContent({ isSticky }: { isSticky: boolean }) {
   );
 
   const isGeneratingAIReport = useAtomValue(isGeneratingAIReportAtom);
+  const isGenerating = !!isGeneratingAIReport && Object.values(isGeneratingAIReport).some((v) => v);
+
+  console.log({ isGeneratingAIReport, isGenerating });
 
   const handleClickAiGenerateSummary = useCallback(() => {
     setAiSummary({
@@ -83,7 +86,7 @@ export default function AiSidebarContent({ isSticky }: { isSticky: boolean }) {
           })}
         >
           <div className="h-full w-full flex-1 space-y-4">
-            {!isGeneratingAIReport && (
+            {!isGenerating && (
               <div className="space-y-2">
                 <span className="text-sm font-semibold text-foreground">Summary text style</span>
                 <RadioGroup
@@ -102,7 +105,7 @@ export default function AiSidebarContent({ isSticky }: { isSticky: boolean }) {
               </div>
             )}
 
-            {!isGeneratingAIReport && (
+            {!isGenerating && (
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <div className="flex space-x-2">
@@ -135,7 +138,7 @@ export default function AiSidebarContent({ isSticky }: { isSticky: boolean }) {
               </div>
             )}
 
-            {isGeneratingAIReport && (
+            {isGenerating && (
               <div className="flex h-full w-full items-center justify-center py-20">
                 <div className="flex w-full flex-col items-center justify-center space-y-2">
                   <span className="h-6 w-6 animate-spin text-blue-500">

--- a/client/src/containers/report/sidebar/ai-content/index.tsx
+++ b/client/src/containers/report/sidebar/ai-content/index.tsx
@@ -48,8 +48,6 @@ export default function AiSidebarContent({ isSticky }: { isSticky: boolean }) {
   const isGeneratingAIReport = useAtomValue(isGeneratingAIReportAtom);
   const isGenerating = !!isGeneratingAIReport && Object.values(isGeneratingAIReport).some((v) => v);
 
-  console.log({ isGeneratingAIReport, isGenerating });
-
   const handleClickAiGenerateSummary = useCallback(() => {
     setAiSummary({
       type: ai_audience,

--- a/client/src/containers/report/sidebar/ai-content/index.tsx
+++ b/client/src/containers/report/sidebar/ai-content/index.tsx
@@ -46,7 +46,10 @@ export default function AiSidebarContent({ isSticky }: { isSticky: boolean }) {
   );
 
   const isGeneratingAIReport = useAtomValue(isGeneratingAIReportAtom);
-  const isGenerating = !!isGeneratingAIReport && Object.values(isGeneratingAIReport).some((v) => v);
+  const isGenerating =
+    aiSummary.enabled &&
+    !!isGeneratingAIReport &&
+    Object.values(isGeneratingAIReport).some((v) => v);
 
   const handleClickAiGenerateSummary = useCallback(() => {
     setAiSummary({

--- a/client/src/containers/results/content/summary.tsx
+++ b/client/src/containers/results/content/summary.tsx
@@ -160,8 +160,14 @@ export const ReportResultsSummary = ({ topic }: ReportResultsSummaryProps) => {
   const setIsGeneratingReport = useSetAtom(isGeneratingAIReportAtom);
 
   useMemo(() => {
-    setIsGeneratingReport(isFetching || isPending);
-  }, [isFetching, isPending, setIsGeneratingReport]);
+    if (!topic) return;
+    setIsGeneratingReport((prev) => {
+      return {
+        ...prev,
+        [`${topic?.id}`]: isFetching || isPending,
+      };
+    });
+  }, [topic, isFetching, isPending, setIsGeneratingReport]);
 
   return (
     <div className="relative">

--- a/client/src/containers/results/content/summary.tsx
+++ b/client/src/containers/results/content/summary.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 
 import { useQueries } from "@tanstack/react-query";
 import { useSetAtom } from "jotai";
+import { usePreviousDifferent } from "rooks";
 
 import { useGetAISummary } from "@/lib/ai";
 import { getQueryFeatureIdOptions, useGetDefaultIndicators } from "@/lib/indicators";
@@ -149,13 +150,12 @@ export const useGetSummaryTopic = (
 
 export const ReportResultsSummary = ({ topic }: ReportResultsSummaryProps) => {
   const [topics] = useSyncTopics();
-  const activeIndicators = topics?.find((t) => t.id === topic?.id)?.indicators?.map(({ id }) => id);
-  const [aiSummary] = useSyncAiSummary();
-  const { data, isFetching, isFetched, isPending } = useGetSummaryTopic(
-    topic,
-    aiSummary,
-    activeIndicators,
-  );
+  const activeIndicators = useMemo(() => {
+    return topics?.find((t) => t.id === topic?.id)?.indicators?.map(({ id }) => id);
+  }, [topic, topics]);
+  const previousActiveIndicators = usePreviousDifferent(activeIndicators ?? undefined);
+  const [aiSummary, setAiSummary] = useSyncAiSummary();
+  const { data, isFetching, isPending } = useGetSummaryTopic(topic, aiSummary, activeIndicators);
 
   const setIsGeneratingReport = useSetAtom(isGeneratingAIReportAtom);
 
@@ -169,9 +169,19 @@ export const ReportResultsSummary = ({ topic }: ReportResultsSummaryProps) => {
     });
   }, [topic, isFetching, isPending, setIsGeneratingReport]);
 
+  useMemo(() => {
+    if (
+      !!previousActiveIndicators &&
+      !!activeIndicators &&
+      activeIndicators.join("") !== previousActiveIndicators.join("")
+    ) {
+      setAiSummary((prev) => ({ ...prev, enabled: false }));
+    }
+  }, [activeIndicators, previousActiveIndicators, setAiSummary]);
+
   return (
     <div className="relative">
-      {(isPending || (isFetching && !isFetched)) && (
+      {(isPending || isFetching) && (
         <div className="space-y-1.5">
           <p>Generating summary...</p>
           <Skeleton className="h-4" />
@@ -180,7 +190,7 @@ export const ReportResultsSummary = ({ topic }: ReportResultsSummaryProps) => {
         </div>
       )}
 
-      {isFetched && !isFetching && data && !!data.description && (
+      {!isFetching && data && !!data.description && (
         <Markdown className="max-w-none xl:prose-base 3xl:prose-lg prose-strong:font-bold">
           {data.description}
         </Markdown>


### PR DESCRIPTION
This pull request includes several changes to improve the handling and display of AI-generated summaries in the application. The changes involve modifications to the state management, UI components, and data fetching logic.

State management improvements:

* [`client/src/app/store.ts`](diffhunk://#diff-193a456494c2f3f521912307d2aa088044a825a60cdad6c5ed52b3ad936cf846L121-R121): Changed the `isGeneratingAIReportAtom` atom from a boolean to a record to track the generation state for multiple reports.

UI component updates:

* [`client/src/containers/report/sidebar/ai-content/index.tsx`](diffhunk://#diff-01843afd37cdb09aff809f84cf6ea9cef7ecfe6ac79cf09b512fbb9addd07a40R49-R52): Updated the `isGeneratingAIReport` logic to use the new record structure and added a new `isGenerating` variable to simplify the conditional rendering of the UI. [[1]](diffhunk://#diff-01843afd37cdb09aff809f84cf6ea9cef7ecfe6ac79cf09b512fbb9addd07a40R49-R52) [[2]](diffhunk://#diff-01843afd37cdb09aff809f84cf6ea9cef7ecfe6ac79cf09b512fbb9addd07a40L86-R90) [[3]](diffhunk://#diff-01843afd37cdb09aff809f84cf6ea9cef7ecfe6ac79cf09b512fbb9addd07a40L105-R109) [[4]](diffhunk://#diff-01843afd37cdb09aff809f84cf6ea9cef7ecfe6ac79cf09b512fbb9addd07a40L138-R142)

Data fetching logic enhancements:

* [`client/src/containers/results/content/summary.tsx`](diffhunk://#diff-038612372f738e0dc3a8ff3709de3de2492752aa20d8f92c16c333e0a01b102bR7): Added `usePreviousDifferent` to track changes in active indicators and updated the `useGetSummaryTopic` hook to handle the new state structure. Also, modified the logic to disable AI summary generation when active indicators change. [[1]](diffhunk://#diff-038612372f738e0dc3a8ff3709de3de2492752aa20d8f92c16c333e0a01b102bR7) [[2]](diffhunk://#diff-038612372f738e0dc3a8ff3709de3de2492752aa20d8f92c16c333e0a01b102bL152-R184) [[3]](diffhunk://#diff-038612372f738e0dc3a8ff3709de3de2492752aa20d8f92c16c333e0a01b102bL177-R193)

Data query adjustments:

* [`client/src/app/local-api/indicators/indicators.json`](diffhunk://#diff-1fc2a0e4bef1afa925dfe38671a8eeb887264d742a3e1711b0d2915d6d7c7c26L2289-R2294): Replaced `outFields` with `outStatistics` to count the number of features in the query.