### PR TITLE
Table: pagination improvements

### DIFF
--- a/client/src/containers/widgets/table/index.tsx
+++ b/client/src/containers/widgets/table/index.tsx
@@ -10,12 +10,12 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { useTranslations } from "next-intl";
-import Pluralize from "pluralize";
 import { LuArrowUpDown } from "react-icons/lu";
 
 import { cn } from "@/lib/utils";
 
 import { DataPagination } from "@/containers/widgets/table/pagination";
+import { TableTotal } from "@/containers/widgets/table/total";
 
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
@@ -117,7 +117,12 @@ export function DataTable<TData, TValue>({
         </ScrollArea>
 
         <footer className="flex shrink-0 items-center justify-between">
-          <p className="text-xs font-medium text-gray-500">{`${data.length} ${Pluralize(t("result"), data.length)}`}</p>
+          <TableTotal
+            total={data.length}
+            pageIndex={pageIndex}
+            pageSize={table.getState().pagination.pageSize}
+          />
+          {/* <p className="text-xs font-medium text-gray-500">{`${data.length} ${Pluralize(t("result"), data.length)}`}</p> */}
           <DataPagination
             pageIndex={pageIndex}
             pageCount={table.getPageCount()}

--- a/client/src/containers/widgets/table/index.tsx
+++ b/client/src/containers/widgets/table/index.tsx
@@ -116,22 +116,24 @@ export function DataTable<TData, TValue>({
           </Table>
         </ScrollArea>
 
-        <footer className="flex shrink-0 items-center justify-between">
-          <TableTotal
-            total={data.length}
-            pageIndex={pageIndex}
-            pageSize={table.getState().pagination.pageSize}
-          />
-          {/* <p className="text-xs font-medium text-gray-500">{`${data.length} ${Pluralize(t("result"), data.length)}`}</p> */}
-          <DataPagination
-            pageIndex={pageIndex}
-            pageCount={table.getPageCount()}
-            totalPagesToDisplay={5}
-            onPagePrevious={table.previousPage}
-            onPageNext={table.nextPage}
-            onPageIndex={table.setPageIndex}
-          />
-        </footer>
+        {!!data.length && (
+          <footer className="flex shrink-0 items-center justify-between">
+            <TableTotal
+              total={data.length}
+              pageIndex={pageIndex}
+              pageSize={table.getState().pagination.pageSize}
+            />
+
+            <DataPagination
+              pageIndex={pageIndex}
+              pageCount={table.getPageCount()}
+              totalPagesToDisplay={5}
+              onPagePrevious={table.previousPage}
+              onPageNext={table.nextPage}
+              onPageIndex={table.setPageIndex}
+            />
+          </footer>
+        )}
       </div>
     </div>
   );

--- a/client/src/containers/widgets/table/pagination.tsx
+++ b/client/src/containers/widgets/table/pagination.tsx
@@ -76,6 +76,10 @@ export function DataPagination({
     ));
   };
 
+  if (pageCount <= 1) {
+    return null; // Don't render pagination if there's only one page
+  }
+
   return (
     <Pagination>
       <PaginationContent>

--- a/client/src/containers/widgets/table/total.tsx
+++ b/client/src/containers/widgets/table/total.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import Pluralize from "pluralize";
+
+export interface TableTotalProps {
+  total: number;
+  pageIndex: number;
+  pageSize: number;
+}
+
+export const TableTotal = ({ total, pageIndex, pageSize }: TableTotalProps) => {
+  const t = useTranslations();
+  const start = pageIndex * pageSize + 1;
+  const end = Math.min(total, (pageIndex + 1) * pageSize);
+
+  {
+    /* <p className="text-xs font-medium text-gray-500">{`${data.length} ${Pluralize(t("result"), data.length)}`}</p> */
+  }
+
+  if (total === 0) return null;
+
+  return (
+    <div className="flex items-center justify-between gap-2 text-xs font-medium text-muted-foreground">
+      <span>{`${start} - ${end}`}</span>
+      {"/"}
+      <strong>{`${total} ${Pluralize(t("result"), total)}`}</strong>
+    </div>
+  );
+};

--- a/client/src/i18n/translations/en.json
+++ b/client/src/i18n/translations/en.json
@@ -123,7 +123,7 @@
   "got-it-alert-button": "Got it",
   "card-no-results": "No results for this location at the moment.  \n  Feel free to adjust your search criteria or check back later!",
   "report-results-buttons-new-report": "New report",
-  "report-results-new-report-description": "Proceed if you wish to generate a new report by selecting a new area. Note that switching areas will refresh your current session, and the existing report will be lost.",
+  "report-results-buttons-new-report-description": "Proceed if you wish to generate a new report by selecting a new area. Note that switching areas will refresh your current session, and the existing report will be lost.",
   "report-results-buttons-edit-report": "Edit report",
   "report-results-disclaimer-part-1": "The maps, data, and geographic information presented on AmazoniaForever360+ are provided for reference purposes only and are intended solely to enhance territorial knowledge of the Amazonia Forever program's work area.",
   "report-results-disclaimer-part-2": "International boundary lines and other  administrative delimitations used by AmazoniaForever360+ are sourced from carefully selected and well-referenced external sources. However, the original data may have been modified to meet cartographic visualization requirements. The cartographic material presented does not reflect any position held by the Inter-American Development Bank (IDB) regarding international borders, disputes, or claims between countries.",

--- a/client/src/i18n/translations/es.json
+++ b/client/src/i18n/translations/es.json
@@ -123,7 +123,7 @@
   "got-it-alert-button": "Got it",
   "card-no-results": "No results for this location at the moment.  \n  Feel free to adjust your search criteria or check back later!",
   "report-results-buttons-new-report": "New report",
-  "report-results-new-report-description": "Proceed if you wish to generate a new report by selecting a new area. Note that switching areas will refresh your current session, and the existing report will be lost.",
+  "report-results-buttons-new-report-description": "Proceed if you wish to generate a new report by selecting a new area. Note that switching areas will refresh your current session, and the existing report will be lost.",
   "report-results-buttons-edit-report": "Edit report",
   "report-results-disclaimer-part-1": "The maps, data, and geographic information presented on AmazoniaForever360+ are provided for reference purposes only and are intended solely to enhance territorial knowledge of the Amazonia Forever program's work area.",
   "report-results-disclaimer-part-2": "International boundary lines and other  administrative delimitations used by AmazoniaForever360+ are sourced from carefully selected and well-referenced external sources. However, the original data may have been modified to meet cartographic visualization requirements. The cartographic material presented does not reflect any position held by the Inter-American Development Bank (IDB) regarding international borders, disputes, or claims between countries.",

--- a/client/src/i18n/translations/pt.json
+++ b/client/src/i18n/translations/pt.json
@@ -123,7 +123,7 @@
   "got-it-alert-button": "Got it",
   "card-no-results": "No results for this location at the moment.  \n  Feel free to adjust your search criteria or check back later!",
   "report-results-buttons-new-report": "New report",
-  "report-results-new-report-description": "Proceed if you wish to generate a new report by selecting a new area. Note that switching areas will refresh your current session, and the existing report will be lost.",
+  "report-results-buttons-new-report-description": "Proceed if you wish to generate a new report by selecting a new area. Note that switching areas will refresh your current session, and the existing report will be lost.",
   "report-results-buttons-edit-report": "Edit report",
   "report-results-disclaimer-part-1": "The maps, data, and geographic information presented on AmazoniaForever360+ are provided for reference purposes only and are intended solely to enhance territorial knowledge of the Amazonia Forever program's work area.",
   "report-results-disclaimer-part-2": "International boundary lines and other  administrative delimitations used by AmazoniaForever360+ are sourced from carefully selected and well-referenced external sources. However, the original data may have been modified to meet cartographic visualization requirements. The cartographic material presented does not reflect any position held by the Inter-American Development Bank (IDB) regarding international borders, disputes, or claims between countries.",


### PR DESCRIPTION
This pull request includes several changes to the `client/src/containers/widgets/table` component, improving the table's functionality and user experience. Additionally, there are minor updates to the translations files.

Improvements to the table component:

* [`client/src/containers/widgets/table/index.tsx`](diffhunk://#diff-473d7e23f958502464d097a5e69e3c72278f97915b0c4d70d9aabdedcad7ad0dL13-R18): Removed the `Pluralize` import and replaced the inline total display with the new `TableTotal` component. This change simplifies the code and improves readability. [[1]](diffhunk://#diff-473d7e23f958502464d097a5e69e3c72278f97915b0c4d70d9aabdedcad7ad0dL13-R18) [[2]](diffhunk://#diff-473d7e23f958502464d097a5e69e3c72278f97915b0c4d70d9aabdedcad7ad0dR119-R126) [[3]](diffhunk://#diff-473d7e23f958502464d097a5e69e3c72278f97915b0c4d70d9aabdedcad7ad0dR136)
* [`client/src/containers/widgets/table/pagination.tsx`](diffhunk://#diff-98e0f125def514a4375f7c8da1d55b2e89d97313c6005861cbbaf8a3514da905R79-R82): Added a condition to prevent rendering the pagination component if there is only one page.
* [`client/src/containers/widgets/table/total.tsx`](diffhunk://#diff-907a2324c0c9c51b53610ecc8d902e3281d533f8a48ab88082d4e53e40e45319R1-R30): Introduced the new `TableTotal` component to display the total number of results and the current page range.

Minor updates to translations:

* `client/src/i18n/translations/en.json`, `client/src/i18n/translations/es.json`, `client/src/i18n/translations/pt.json`: Fixed a typo in the key `report-results-buttons-new-report-description`.