### PR TITLE
Proxy: remove response headers

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -1,6 +1,5 @@
-import "./src/env.mjs";
-
 import createNextIntlPlugin from "next-intl/plugin";
+import "./src/env.mjs";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/client/src/containers/providers/arcgis.tsx
+++ b/client/src/containers/providers/arcgis.tsx
@@ -12,10 +12,7 @@ export const ArcGISProvider = ({ children }: PropsWithChildren) => {
     esriConfig.apiKey = env.NEXT_PUBLIC_ARCGIS_API_KEY;
 
     esriConfig.request.interceptors?.push({
-      urls: [env.NEXT_PUBLIC_API_URL],
-      headers: {
-        Authorization: `Bearer ${env.NEXT_PUBLIC_API_KEY}`,
-      },
+      urls: [`/custom-api`],
     });
 
     esriConfig.request.interceptors?.push({

--- a/client/src/containers/report/map/layer-manager/grid-layer.tsx
+++ b/client/src/containers/report/map/layer-manager/grid-layer.tsx
@@ -17,8 +17,6 @@ import CHROMA from "chroma-js";
 import { cellToLatLng, latLngToCell } from "h3-js";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
-import { env } from "@/env.mjs";
-
 import { useMeta } from "@/lib/grid";
 import { getGeometryWithBuffer, useLocationGeometry } from "@/lib/location";
 
@@ -76,7 +74,7 @@ export const getGridLayerProps = ({
 
   return new H3TileLayer({
     id: `tile-h3s`,
-    data: `${env.NEXT_PUBLIC_API_URL}/grid/tile/{h3index}?${columns}`,
+    data: `/custom-api/grid/tile/{h3index}?${columns}`,
     extent: [-80.3603, -36.5016, -43.8134, 20.8038],
     visible: !!gridDatasets.length && gridSelectedDataset !== "no-layer",
     getTileData: (tile) => {
@@ -97,7 +95,6 @@ export const getGridLayerProps = ({
             }),
           }),
           headers: {
-            Authorization: `Bearer ${env.NEXT_PUBLIC_API_KEY}`,
             "Content-Type": "application/json",
           },
         },

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -19,26 +19,29 @@ export default async function middleware(req: NextRequest) {
     const url = req.nextUrl.clone();
     url.pathname = req.nextUrl.pathname.replace(API_URL, "");
 
+    const requestHeaders = new Headers(req.headers);
+    requestHeaders.set("Authorization", `Bearer ${env.NEXT_PUBLIC_API_KEY}`);
+
     const res = NextResponse.rewrite(
-      new URL(env.NEXT_PUBLIC_API_URL + url.pathname, req.nextUrl.origin),
+      new URL(`${env.NEXT_PUBLIC_API_URL}${url.pathname}?${url.search}`, req.url),
+      {
+        request: {
+          headers: requestHeaders,
+        },
+      },
     );
 
     // Set CORS headers for the response
-    res.headers.set("Authorization", `Bearer ${env.NEXT_PUBLIC_API_KEY}`);
-    res.headers.set("Access-Control-Allow-Origin", "*");
-    res.headers.set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
-    res.headers.set(
-      "Access-Control-Allow-Headers",
-      "Origin, X-Requested-With, Content-Type, Accept, Authorization",
-    );
-    res.headers.set("Access-Control-Allow-Credentials", "true");
-    res.headers.set("Access-Control-Expose-Headers", "Content-Disposition");
-    res.headers.set("Access-Control-Max-Age", "86400");
-
-    // Handle pre-flight requests
-    if (req.method === "OPTIONS") {
-      return new NextResponse("ok", { status: 200 });
-    }
+    // res.headers.set("Authorization", `Bearer ${env.NEXT_PUBLIC_API_KEY}`);
+    // res.headers.set("Access-Control-Allow-Origin", "*");
+    // res.headers.set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+    // res.headers.set(
+    //   "Access-Control-Allow-Headers",
+    //   "Origin, X-Requested-With, Content-Type, Accept, Authorization",
+    // );
+    // res.headers.set("Access-Control-Allow-Credentials", "true");
+    // res.headers.set("Access-Control-Expose-Headers", "Content-Disposition");
+    // res.headers.set("Access-Control-Max-Age", "86400");
 
     return res;
   }

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -31,18 +31,6 @@ export default async function middleware(req: NextRequest) {
       },
     );
 
-    // Set CORS headers for the response
-    // res.headers.set("Authorization", `Bearer ${env.NEXT_PUBLIC_API_KEY}`);
-    // res.headers.set("Access-Control-Allow-Origin", "*");
-    // res.headers.set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
-    // res.headers.set(
-    //   "Access-Control-Allow-Headers",
-    //   "Origin, X-Requested-With, Content-Type, Accept, Authorization",
-    // );
-    // res.headers.set("Access-Control-Allow-Credentials", "true");
-    // res.headers.set("Access-Control-Expose-Headers", "Content-Disposition");
-    // res.headers.set("Access-Control-Max-Age", "86400");
-
     return res;
   }
 

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1,10 +1,8 @@
 import Axios, { AxiosError, AxiosRequestConfig } from "axios";
 import qs from "query-string";
 
-import { env } from "@/env.mjs";
-
 export const AXIOS_INSTANCE = Axios.create({
-  baseURL: env.NEXT_PUBLIC_API_URL,
+  baseURL: "/custom-api",
 });
 
 export const API = <T>(config: AxiosRequestConfig, options?: AxiosRequestConfig): Promise<T> => {
@@ -13,9 +11,6 @@ export const API = <T>(config: AxiosRequestConfig, options?: AxiosRequestConfig)
   const promise = AXIOS_INSTANCE({
     ...config,
     ...options,
-    headers: {
-      Authorization: `Bearer ${env.NEXT_PUBLIC_API_KEY}`,
-    },
     cancelToken: source.token,
     paramsSerializer: (params) => {
       return qs.stringify(params);


### PR DESCRIPTION
This pull request includes several changes to the client-side configuration and API request handling. The main focus of the changes is to update the API base URLs and modify authorization handling.

### Changes to API base URLs and authorization handling:

* [`client/src/containers/providers/arcgis.tsx`](diffhunk://#diff-8f88b9e6fa1b6ff5f1c408d6896774926f9964b924e146f1d6348ba789debb55L15-R15): Updated the `ArcGISProvider` component to change the `urls` property in the `esriConfig.request.interceptors` to use `/custom-api` instead of `env.NEXT_PUBLIC_API_URL` and removed the `Authorization` header.
* [`client/src/containers/report/map/layer-manager/grid-layer.tsx`](diffhunk://#diff-5b968f3049591627cff4f1d3ca36b923e211d6b3650629a4c261c5396671f93cL79-R77): Modified the `getGridLayerProps` function to update the `data` property to use `/custom-api/grid/tile/{h3index}?${columns}` instead of `env.NEXT_PUBLIC_API_URL/grid/tile/{h3index}?${columns}` and removed the `Authorization` header from the request headers. [[1]](diffhunk://#diff-5b968f3049591627cff4f1d3ca36b923e211d6b3650629a4c261c5396671f93cL79-R77) [[2]](diffhunk://#diff-5b968f3049591627cff4f1d3ca36b923e211d6b3650629a4c261c5396671f93cL100)
* [`client/src/services/api.ts`](diffhunk://#diff-ac12ccf4a992280fc6133152846dbaacba4f07ff21901b404635932d3cf94ce9L4-R5): Changed the `baseURL` in the `AXIOS_INSTANCE` to `/custom-api` instead of `env.NEXT_PUBLIC_API_URL` and removed the `Authorization` header from the API request configuration. [[1]](diffhunk://#diff-ac12ccf4a992280fc6133152846dbaacba4f07ff21901b404635932d3cf94ce9L4-R5) [[2]](diffhunk://#diff-ac12ccf4a992280fc6133152846dbaacba4f07ff21901b404635932d3cf94ce9L16-L18)

### Configuration file changes:

* [`client/next.config.mjs`](diffhunk://#diff-cb812c116d64599741bb86378307e03a2c09cb721e864b252e386c133f144c7fL1-R2): Moved the import statement for `./src/env.mjs` to ensure it is imported after `createNextIntlPlugin`.

### Middleware updates:

* [`client/src/middleware.ts`](diffhunk://#diff-e9afcce1307f539338e73b9d862ceaa5bf8be0ab3d07f702f41e024342ae748cR22-R44): Updated the `middleware` function to set the `Authorization` header in the request headers and adjusted the URL construction for the rewritten request. Removed the setting of CORS headers and handling of pre-flight requests.