### PR TITLE
Sketch mobile drawing button now completes the polygon - Am 347

### DIFF
--- a/client/src/components/map/sketch/index.tsx
+++ b/client/src/components/map/sketch/index.tsx
@@ -93,13 +93,17 @@ export default function Sketch({
       if (onCreateChange) onCreateChange(e);
 
       if (e.state === "complete" && sketchViewModelRef.current) {
-        const g = e.graphic.clone();
+        if (e.graphic.geometry) {
+          const g = e.graphic.clone();
 
-        if (type !== undefined) {
-          g.symbol = sketchViewModelRef.current[`${type}Symbol`].clone();
+          if (type !== undefined) {
+            g.symbol = sketchViewModelRef.current[`${type}Symbol`].clone();
+          }
+
+          if (onCreate) onCreate(g);
+        } else {
+          if (onCancel) onCancel();
         }
-
-        if (onCreate) onCreate(g);
       }
 
       if (e.state === "cancel") {

--- a/client/src/components/map/sketch/index.tsx
+++ b/client/src/components/map/sketch/index.tsx
@@ -30,6 +30,7 @@ export type SketchProps = {
   type?: "point" | "polygon" | "polyline";
   enabled?: boolean;
   updatable?: boolean;
+  completed?: boolean;
   location?: Location | null;
   onCreate?: (graphic: __esri.Graphic) => void;
   onCreateChange?: (e: __esri.SketchViewModelCreateEvent) => void;
@@ -41,6 +42,7 @@ export type SketchProps = {
 export default function Sketch({
   type,
   enabled,
+  completed = false,
   updatable = true,
   location,
   onCreate,
@@ -156,6 +158,7 @@ export default function Sketch({
       polygonSymbol: POLYGON_SYMBOL,
       defaultCreateOptions: {
         hasZ: false,
+        mode: "click",
       },
       defaultUpdateOptions: {
         tool: "reshape",
@@ -221,6 +224,12 @@ export default function Sketch({
       sketchViewModelRef.current.updateOnGraphicClick = updatable;
     }
   }, [location, updatable, LOCATION, drawBuffer, handleListeners]);
+
+  useEffect(() => {
+    if (completed) {
+      sketchViewModelRef.current?.complete();
+    }
+  }, [completed]);
 
   return (
     <>

--- a/client/src/containers/report/location/sketch/mobile.tsx
+++ b/client/src/containers/report/location/sketch/mobile.tsx
@@ -23,17 +23,7 @@ export default function SketchMobile() {
     setLocation(null);
 
     if (sketch.enabled && sketch.type === type) {
-      setSketch({ enabled: false, type: undefined });
-      setSketchAction({ type: undefined, state: undefined, geometryType: undefined });
-    }
-
-    if (sketch.enabled && sketch.type !== type) {
-      setSketch({ enabled: false, type: undefined });
-
-      setTimeout(() => {
-        setSketch({ enabled: true, type });
-        setSketchAction({ type: "create", state: "start", geometryType: type });
-      }, 0);
+      setSketchAction({ type: "create", state: "complete", geometryType: type });
     }
 
     if (!sketch.enabled) {
@@ -54,7 +44,8 @@ export default function SketchMobile() {
         onClick={(e) => handleClick(e, "polygon")}
         type="button"
       >
-        {t("grid-sketch-start-drawing")}
+        {sketch.enabled && sketch.type === "polygon" && t("grid-sketch-finish-drawing")}
+        {!sketch.enabled && t("grid-sketch-start-drawing")}
       </Button>
     </div>
   );

--- a/client/src/containers/report/map/index.tsx
+++ b/client/src/containers/report/map/index.tsx
@@ -43,7 +43,7 @@ export default function MapContainer({ desktop }: { desktop?: boolean }) {
   const [tmpBbox, setTmpBbox] = useAtom(tmpBboxAtom);
 
   const [sketch, setSketch] = useAtom(sketchAtom);
-  const setSketchAction = useSetAtom(sketchActionAtom);
+  const [sketchAction, setSketchAction] = useAtom(sketchActionAtom);
   const sketchActionTimeoutRef = useRef<NodeJS.Timeout>();
 
   const setGridHover = useSetAtom(gridHoverAtom);
@@ -166,6 +166,7 @@ export default function MapContainer({ desktop }: { desktop?: boolean }) {
           type={sketch.type}
           enabled={sketch.enabled}
           updatable={location?.type !== "search" && tab === "contextual-viewer"}
+          completed={sketchAction.type === "create" && sketchAction.state === "complete"}
           location={location}
           onCreate={handleCreate}
           onCreateChange={handleCreateChange}

--- a/client/src/i18n/translations/en.json
+++ b/client/src/i18n/translations/en.json
@@ -99,6 +99,7 @@
   "grid-sidebar-grid-filters-ranking-set-up-max-number-cell-note": "Higher numbers will take more time",
   "grid-sidebar-grid-filters-ranking-set-up-button-apply": "Apply",
   "grid-sketch-start-drawing": "Start drawing",
+  "grid-sketch-finish-drawing": "Finish drawing",
   "grid-sketch-tooltip-create-start-polygon": "To get started, **click** on the map to add point. Press **ESC** to cancel.",
   "grid-sketch-tooltip-create-active-polygon": "Click to add points, then **double-click** or press **Enter** to finish drawing.",
   "grid-sketch-tooltip-create-complete-polygon": "Great! To **edit the shape**, **click** on it to enable edit mode.",

--- a/client/src/i18n/translations/es.json
+++ b/client/src/i18n/translations/es.json
@@ -99,6 +99,7 @@
   "grid-sidebar-grid-filters-ranking-set-up-max-number-cell-note": "Las cifras más altas requerirán más tiempo",
   "grid-sidebar-grid-filters-ranking-set-up-button-apply": "Aplicar",
   "grid-sketch-start-drawing": "Empezar a dibujar",
+  "grid-sketch-finish-drawing": "Terminar de dibujar",
   "grid-sketch-tooltip-create-start-polygon": "Para empezar, **haga clic** en el mapa para añadir un punto. Pulsa **ESC** para cancelar.",
   "grid-sketch-tooltip-create-active-polygon": "Haz clic para añadir puntos y, a continuación, **doble clic** o pulsa **Intro** para terminar de dibujar.",
   "grid-sketch-tooltip-create-complete-polygon": "Genial. Para **editar la forma**, **haz clic** en ella para activar el modo de edición.",

--- a/client/src/i18n/translations/pt.json
+++ b/client/src/i18n/translations/pt.json
@@ -99,6 +99,7 @@
   "grid-sidebar-grid-filters-ranking-set-up-max-number-cell-note": "Números mais elevados requerem mais tempo",
   "grid-sidebar-grid-filters-ranking-set-up-button-apply": "Aplicar",
   "grid-sketch-start-drawing": "Começar a desenhar",
+  "grid-sketch-finish-drawing": "Terminar o desenho",
   "grid-sketch-tooltip-create-start-polygon": "Para começar, **clique** no mapa para adicionar um ponto. Aperte **ESC** para cancelar.",
   "grid-sketch-tooltip-create-active-polygon": "Clique para adicionar pontos e, em seguida, **clique duas vezes** ou aperte **Enter** para finalizar o desenho.",
   "grid-sketch-tooltip-create-complete-polygon": "Ótimo. Para **editar a forma**, **clique** na mesma para ativar o modo de edição.",


### PR DESCRIPTION
This pull request introduces enhancements to the `Sketch` component and related functionality to improve handling of drawing operations in the map interface. Key changes include adding support for marking sketches as completed, refining behavior for handling incomplete graphics, updating button text dynamically, and introducing new translations for improved localization.

### Enhancements to the `Sketch` component:

* Added a new `completed` property to `SketchProps` and defaulted it to `false` in the `Sketch` component. This allows marking a sketch operation as completed programmatically. (`client/src/components/map/sketch/index.tsx`, [[1]](diffhunk://#diff-a30a71e0bab3114ce469340caca3aa858b104b6bf586692b987540594c11f675R33) [[2]](diffhunk://#diff-a30a71e0bab3114ce469340caca3aa858b104b6bf586692b987540594c11f675R45)
* Introduced logic to handle incomplete graphics in the `onCreateChange` callback. If the geometry is missing, the `onCancel` callback is triggered. (`client/src/components/map/sketch/index.tsx`, [client/src/components/map/sketch/index.tsxR96-R106](diffhunk://#diff-a30a71e0bab3114ce469340caca3aa858b104b6bf586692b987540594c11f675R96-R106))
* Updated the default `mode` for sketch creation to `"click"` for improved usability. (`client/src/components/map/sketch/index.tsx`, [client/src/components/map/sketch/index.tsxR165](diffhunk://#diff-a30a71e0bab3114ce469340caca3aa858b104b6bf586692b987540594c11f675R165))
* Added a `useEffect` hook to automatically complete sketches when the `completed` property is set to `true`. (`client/src/components/map/sketch/index.tsx`, [client/src/components/map/sketch/index.tsxR232-R237](diffhunk://#diff-a30a71e0bab3114ce469340caca3aa858b104b6bf586692b987540594c11f675R232-R237))

### Improvements to the `SketchMobile` component:

* Simplified the logic for handling sketch actions by directly setting the state to `"complete"` when the sketch type matches the active type. (`client/src/containers/report/location/sketch/mobile.tsx`, [client/src/containers/report/location/sketch/mobile.tsxL26-R26](diffhunk://#diff-c139278a67af3c703858855c80848f45bd791e355e0adcb5452d1fa787b004d9L26-R26))
* Updated button text dynamically based on the sketch state, displaying "Finish drawing" when a polygon sketch is active and "Start drawing" otherwise. (`client/src/containers/report/location/sketch/mobile.tsx`, [client/src/containers/report/location/sketch/mobile.tsxL57-R48](diffhunk://#diff-c139278a67af3c703858855c80848f45bd791e355e0adcb5452d1fa787b004d9L57-R48))

### Updates to `MapContainer`:

* Modified the `sketchActionAtom` to use both getter and setter, enabling better state management for sketch actions. (`client/src/containers/report/map/index.tsx`, [client/src/containers/report/map/index.tsxL46-R46](diffhunk://#diff-7cec6a755a386b59b426e1ada313d1917a23eb7097ff0447253ffdca9281949aL46-R46))
* Passed the `completed` property to the `Sketch` component, derived from the sketch action's type and state. (`client/src/containers/report/map/index.tsx`, [client/src/containers/report/map/index.tsxR169](diffhunk://#diff-7cec6a755a386b59b426e1ada313d1917a23eb7097ff0447253ffdca9281949aR169))

### Localization updates:

* Added translations for "Finish drawing" in English, Spanish, and Portuguese to support dynamic button text in the sketch interface. (`client/src/i18n/translations/en.json`, [[1]](diffhunk://#diff-6e769d175a52cf1c8ed7455bb8552e1e03a8f7f1edd3a0f58d43a12b53118bdfR102); `client/src/i18n/translations/es.json`, [[2]](diffhunk://#diff-054613f71c6705e65481113adfb1f316932d852f3771dccb716168dbcddf9be2R102); `client/src/i18n/translations/pt.json`, [[3]](diffhunk://#diff-7730ca396e188a06252899ecd50484ee49e0f8211dd596598368c06a026482d6R102)