### PR TITLE
Add NEXT_PUBLIC_FEATURE_PARTNERS as true only for develop environment

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -119,7 +119,7 @@ jobs:
             NEXT_PUBLIC_URL=http://0.0.0.0:3000
             NEXT_PUBLIC_API_URL=${{ vars.TF_CLIENT_NEXT_PUBLIC_API_URL }}
             NEXT_PUBLIC_ARCGIS_API_KEY=${{ secrets.TF_CLIENT_NEXT_PUBLIC_ARCGIS_API_KEY }}
-            NEXT_PUBLIC_FEATURE_PARTNERS=${{ vars.TF_CLIENT_NEXT_PUBLIC_FEATURE_PARTNERS }}
+            NEXT_PUBLIC_FEATURE_PARTNERS=${{ needs.set_environment.outputs.env_name == 'develop' && 'true' || vars.TF_CLIENT_NEXT_PUBLIC_FEATURE_PARTNERS }}
             NEXT_PUBLIC_API_KEY=${{ secrets.TF_CLIENT_NEXT_PUBLIC_API_KEY }}
             BASIC_AUTH_ENABLED=${{ vars.TF_CLIENT_BASIC_AUTH_ENABLED }}
             BASIC_AUTH_USER=${{ secrets.TF_CLIENT_BASIC_AUTH_USER }}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -166,6 +166,7 @@ module "staging" {
     # Client
     TF_CLIENT_NEXT_PUBLIC_API_URL = var.staging.client.next_public_api_url
     TF_CLIENT_BASIC_AUTH_ENABLED = var.staging.client.basic_auth_enabled
+    TF_NEXT_PUBLIC_FEATURE_PARTNERS = var.staging.client.next_public_feature_partners
   }
   github_additional_environment_secrets = {
     # API
@@ -175,7 +176,6 @@ module "staging" {
     TF_CLIENT_NEXT_PUBLIC_API_KEY = var.staging.client.next_public_api_key
     TF_CLIENT_NEXT_PUBLIC_ARCGIS_API_KEY = var.staging.client.next_public_arcgis_api_key
 
-    TF_NEXT_PUBLIC_FEATURE_PARTNERS = var.staging.client.next_public_feature_partners
 
     TF_CLIENT_BASIC_AUTH_USER = var.staging.client.basic_auth_user
     TF_CLIENT_BASIC_AUTH_PASSWORD = var.staging.client.basic_auth_password
@@ -210,6 +210,7 @@ module "prod" {
     # Client
     TF_CLIENT_NEXT_PUBLIC_API_URL = var.prod.client.next_public_api_url
     TF_CLIENT_BASIC_AUTH_ENABLED = var.prod.client.basic_auth_enabled
+    TF_NEXT_PUBLIC_FEATURE_PARTNERS = var.prod.client.next_public_feature_partners
   }
   github_additional_environment_secrets = {
     # API
@@ -218,7 +219,6 @@ module "prod" {
     # Client
     TF_CLIENT_NEXT_PUBLIC_API_KEY = var.prod.client.next_public_api_key
     TF_CLIENT_NEXT_PUBLIC_ARCGIS_API_KEY = var.prod.client.next_public_arcgis_api_key
-    TF_NEXT_PUBLIC_FEATURE_PARTNERS = var.prod.client.next_public_feature_partners
     TF_CLIENT_BASIC_AUTH_USER = var.prod.client.basic_auth_user
     TF_CLIENT_BASIC_AUTH_PASSWORD = var.prod.client.basic_auth_password
   }


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/cicd.yml` file to dynamically set the `NEXT_PUBLIC_FEATURE_PARTNERS` environment variable based on the deployment environment.

### Workflow Configuration Update:

* [`.github/workflows/cicd.yml`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L122-R122): Updated the `NEXT_PUBLIC_FEATURE_PARTNERS` variable to evaluate whether the deployment environment is `develop`. If true, it sets the value to `'true'`; otherwise, it defaults to the existing variable `vars.TF_CLIENT_NEXT_PUBLIC_FEATURE_PARTNERS`.