### PR TITLE
Bug: correct texts in home page

### DIFF
--- a/client/src/containers/home/key-features-grid/cards-container.tsx
+++ b/client/src/containers/home/key-features-grid/cards-container.tsx
@@ -72,7 +72,7 @@ export default function CardsContainer() {
           >
             <WandIcon className="text-cyan-600" />
             <h4 className="font-bold text-blue-500">
-              {t("landing-key-features-grid-buttons-identify-hot-spots")}
+              {t("landing-key-features-grid-buttons-redefine-your-area")}
             </h4>
           </div>
         </li>

--- a/client/src/i18n/translations/es.json
+++ b/client/src/i18n/translations/es.json
@@ -21,7 +21,7 @@
   "landing-key-features-report-buttons-share-and-download": "Compartir y descargar",
   "landing-key-features-grid-title": "El poder del Amazonia Grid",
   "landing-key-features-grid-description": "Más allá del reporte, profundice en el área seleccionada utilizando nuestro **sistema de cuadrícula hexagonal** estandarizada para jugar con los indicadores e identificar ubicaciones que coincidan con sus criterios específicos, desde puntos críticos de biodiversidad hasta patrones demográficos.",
-  "landing-key-features-grid-buttons-identify-hot-spots": "Identificar lareas de interes",
+  "landing-key-features-grid-buttons-identify-hot-spots": "Identificar areas de interes",
   "landing-key-features-grid-buttons-redefine-your-area": "Redefina su area",
   "landing-key-features-grid-buttons-create-report": "Crear reporte",
   "landing-information-on-note": "información sobre",


### PR DESCRIPTION
This pull request updates the label for a key feature button in the home grid and improves the Spanish translation for that section. The main changes are focused on updating UI text and fixing a translation typo.

UI text update:

* Changed the button label in `CardsContainer` from "Identify Hot Spots" to "Redefine Your Area" to better reflect the feature's functionality (`cards-container.tsx`).

Translation improvements:

* Fixed a typo in the Spanish translation for "Identify Hot Spots" and added a new translation for "Redefine Your Area" in `es.json`.