### PR TITLE
Bug: Publication icon

### DIFF
--- a/client/src/containers/results/content/other-resources/resource.tsx
+++ b/client/src/containers/results/content/other-resources/resource.tsx
@@ -57,9 +57,10 @@ export default function Resource({
             {Type === "Technical Notes" && (
               <LucideFilePenLine size={40} strokeWidth={1.5} className="text-blue-400" />
             )}
-            {Type === "Working Papers" && (
-              <LuFileText size={40} strokeWidth={1.5} className="text-blue-400" />
-            )}
+            {Type === "Working Papers" ||
+              (Type === "Publications" && (
+                <LuFileText size={40} strokeWidth={1.5} className="text-blue-400" />
+              ))}
           </div>
           <div className="flex flex-col space-y-2">
             <h3 title={Name} className="line-clamp-3 text-base font-semibold text-blue-500">


### PR DESCRIPTION
This pull request makes a small change to the icon rendering logic in the `Resource` component, improving how resource types are displayed.

* Updated the condition for displaying the `LuFileText` icon so that it now appears for both "Working Papers" and "Publications" resource types, ensuring consistent visual representation for these types.