### PR TITLE
Grid: units

### DIFF
--- a/client/src/containers/report/grid/desktop.tsx
+++ b/client/src/containers/report/grid/desktop.tsx
@@ -27,7 +27,7 @@ export default function ReportLocationDesktop() {
                   onValueChange={(value) => setGridPanel(value as "filters" | "table")}
                   className="relative flex grow flex-col overflow-hidden"
                 >
-                  <TabsList className="absolute right-6 top-6 z-10">
+                  <TabsList className="absolute right-6 top-6 z-10 space-x-0.5 rounded-lg border border-border bg-secondary p-0.5">
                     <TabsTrigger value="filters" asChild>
                       <Button size="sm" variant={gridPanel === "filters" ? "default" : "secondary"}>
                         {t("grid-sidebar-grid-tab")}

--- a/client/src/containers/report/grid/filters/search.tsx
+++ b/client/src/containers/report/grid/filters/search.tsx
@@ -57,14 +57,14 @@ export default function SearchC({ className }: { className?: string }) {
       );
 
       return {
-        label: indicator[`name_${locale}` as keyof typeof indicator] ?? "",
+        label: indicator.name ?? "",
         value: matchingDataset?.var_name ?? "",
         key: matchingDataset?.var_name ?? "",
         sourceIndex: index,
         active: matchingDataset?.var_name && gridDatasets?.includes(matchingDataset.var_name),
       } as Option;
     });
-  }, [H3IndicatorsData, META, gridDatasets, selectedFiltersView, locale]);
+  }, [H3IndicatorsData, META, gridDatasets, selectedFiltersView]);
 
   const OPTIONS = useMemo(() => {
     if (search) {

--- a/client/src/containers/report/grid/table/index.tsx
+++ b/client/src/containers/report/grid/table/index.tsx
@@ -109,8 +109,8 @@ export default function GridTable() {
 
     if (!d) return "";
 
-    return (d[`name_${locale}` as keyof typeof d] as string) ?? "";
-  }, [gridDatasets, queryH3Indicators.data, locale]);
+    return d.name ?? "";
+  }, [gridDatasets, queryH3Indicators.data]);
 
   return (
     <div className="space-y-2">

--- a/client/src/containers/results/content/summary.tsx
+++ b/client/src/containers/results/content/summary.tsx
@@ -100,7 +100,7 @@ export const useGetSummaryTopicData = (topic?: Topic, indicators?: Indicator["id
       const q = queries[i];
 
       return {
-        name: d[`name_${locale}` as keyof Indicator],
+        name: d.name,
         data:
           q?.data?.features.map((f) =>
             omit(f.attributes, ["Shape__Area", "Shape__Length", "FID", "Id", "OBJECTID"]),

--- a/client/src/lib/indicators.ts
+++ b/client/src/lib/indicators.ts
@@ -51,6 +51,7 @@ export const getIndicators = async (locale: string) => {
           name: indicator[`name_${locale}` as keyof typeof indicator],
           description: indicator[`description_${locale}` as keyof typeof indicator],
           description_short: indicator[`description_short_${locale}` as keyof typeof indicator],
+          unit: indicator[`unit_${locale}` as keyof typeof indicator],
           topic: topics.find((topic) => topic.id === indicator.topic),
         }) as Indicator,
     )

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -64,7 +64,7 @@
 
 @layer base {
   body {
-    @apply bg-background font-semibold text-foreground;
+    @apply bg-background font-semibold text-foreground antialiased;
   }
 
   .same-trigger-size {


### PR DESCRIPTION
This pull request primarily refactors how indicator names are handled throughout the reporting grid and summary components, standardizing the use of the `name` property instead of locale-specific keys. Additionally, it introduces minor UI and style improvements. The most important changes are grouped below:

**Refactoring indicator name usage:**

* Replaced locale-specific indicator name references (e.g., `name_${locale}`) with the generic `name` property in the grid filters search component (`search.tsx`), grid table component (`table/index.tsx`), and summary topic data hook (`summary.tsx`). This simplifies data handling and ensures consistency across the app. [[1]](diffhunk://#diff-a6a88a3c15ce46ab145822957b85c9d4b69d5185a8d5816d92659229f2bd00d4L60-R67) [[2]](diffhunk://#diff-16657cf6ee5e0c7f43eca0800a6eee07ee0dc17376e182469621f8037e69c6d6L112-R113) [[3]](diffhunk://#diff-038612372f738e0dc3a8ff3709de3de2492752aa20d8f92c16c333e0a01b102bL103-R103)
* Updated the dependency arrays for relevant React hooks to remove `locale`, since indicator names are no longer locale-dependent. [[1]](diffhunk://#diff-a6a88a3c15ce46ab145822957b85c9d4b69d5185a8d5816d92659229f2bd00d4L60-R67) [[2]](diffhunk://#diff-16657cf6ee5e0c7f43eca0800a6eee07ee0dc17376e182469621f8037e69c6d6L112-R113)

**UI and style improvements:**

* Enhanced the appearance of the grid sidebar tabs by adding spacing, rounded borders, and background styling to the `TabsList` element in `desktop.tsx`.
* Added the `antialiased` utility to the global body styles for improved font rendering.

**Indicator data structure update:**

* Added a locale-specific `unit` property to the indicator object in `indicators.ts` to support localized units for indicators.