### PR TITLE
Third party

### DIFF
--- a/client/src/app/[locale]/(app)/layout.tsx
+++ b/client/src/app/[locale]/(app)/layout.tsx
@@ -4,7 +4,6 @@ import { Metadata } from "next";
 
 import { Montserrat } from "next/font/google";
 import { notFound } from "next/navigation";
-import Script from "next/script";
 
 import { hasLocale, NextIntlClientProvider } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
@@ -12,6 +11,7 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import RootHead from "@/app/head";
 
 import Header from "@/containers/header";
+import ThirdParty from "@/containers/third-party";
 
 import { SidebarProvider } from "@/components/ui/sidebar";
 
@@ -84,35 +84,11 @@ export default async function RootLayout({
             <SidebarProvider>
               <Header />
               {children}
+              <ThirdParty />
             </SidebarProvider>
           </NextIntlClientProvider>
         </Suspense>
       </body>
-
-      <Script id="fullstory" strategy="lazyOnload">
-        {`
-              window['_fs_host'] = 'fullstory.com';
-              window['_fs_script'] = 'edge.fullstory.com/s/fs.js';
-              window['_fs_org'] = 'o-206Z64-na1';
-              window['_fs_namespace'] = 'FS';
-              !function(m,n,e,t,l,o,g,y){var s,f,a=function(h){
-              return!(h in m)||(m.console&&m.console.log&&m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].'),!1)}(e)
-              ;function p(b){var h,d=[];function j(){h&&(d.forEach((function(b){var d;try{d=b[h[0]]&&b[h[0]](h[1])}catch(h){return void(b[3]&&b[3](h))}
-              d&&d.then?d.then(b[2],b[3]):b[2]&&b[2](d)})),d.length=0)}function r(b){return function(d){h||(h=[b,d],j())}}return b(r(0),r(1)),{
-              then:function(b,h){return p((function(r,i){d.push([b,h,r,i]),j()}))}}}a&&(g=m[e]=function(){var b=function(b,d,j,r){function i(i,c){
-              h(b,d,j,i,c,r)}r=r||2;var c,u=/Async$/;return u.test(b)?(b=b.replace(u,""),"function"==typeof Promise?new Promise(i):p(i)):h(b,d,j,c,c,r)}
-              ;function h(h,d,j,r,i,c){return b._api?b._api(h,d,j,r,i,c):(b.q&&b.q.push([h,d,j,r,i,c]),null)}return b.q=[],b}(),y=function(b){function h(h){
-              "function"==typeof h[4]&&h[4](new Error(b))}var d=g.q;if(d){for(var j=0;j<d.length;j++)h(d[j]);d.length=0,d.push=h}},function(){
-              (o=n.createElement(t)).async=!0,o.crossOrigin="anonymous",o.src="https://"+l,o.onerror=function(){y("Error loading "+l)}
-              ;var b=n.getElementsByTagName(t)[0];b&&b.parentNode?b.parentNode.insertBefore(o,b):n.head.appendChild(o)}(),function(){function b(){}
-              function h(b,h,d){g(b,h,d,1)}function d(b,d,j){h("setProperties",{type:b,properties:d},j)}function j(b,h){d("user",b,h)}function r(b,h,d){j({
-              uid:b},d),h&&j(h,d)}g.identify=r,g.setUserVars=j,g.identifyAccount=b,g.clearUserCookie=b,g.setVars=d,g.event=function(b,d,j){h("trackEvent",{
-              name:b,properties:d},j)},g.anonymize=function(){r(!1)},g.shutdown=function(){h("shutdown")},g.restart=function(){h("restart")},
-              g.log=function(b,d){h("log",{level:b,msg:d})},g.consent=function(b){h("setIdentity",{consent:!arguments.length||b})}}(),s="fetch",
-              f="XMLHttpRequest",g._w={},g._w[f]=m[f],g._w[s]=m[s],m[s]&&(m[s]=function(){return g._w[s].apply(this,arguments)}),g._v="2.0.0")
-              }(window,document,window._fs_namespace,"script",window._fs_script);
-          `}
-      </Script>
     </>
   );
 }

--- a/client/src/containers/third-party/index.tsx
+++ b/client/src/containers/third-party/index.tsx
@@ -68,11 +68,11 @@ const ThirdParty: React.FC = () => {
       )}
 
       <Dialog open={consent === undefined}>
-        <DialogContent className="max-w-3xl">
+        <DialogContent className="max-w-lg">
           <DialogTitle className="text-2xl">{t("content-title")}</DialogTitle>
           <DialogDescription className="sr-only">{t("consent-message")}</DialogDescription>
-          <Markdown className="prose-base">{t("consent-message")}</Markdown>
-          <DialogFooter className="justify-end">
+          <Markdown>{t("consent-message")}</Markdown>
+          <DialogFooter className="mt-5 justify-end">
             <Button
               size="lg"
               onClick={() => {
@@ -83,7 +83,7 @@ const ThirdParty: React.FC = () => {
             </Button>
             <Button
               size="lg"
-              variant="secondary"
+              variant="outline"
               onClick={() => {
                 handleCookieClick(false);
               }}

--- a/client/src/containers/third-party/index.tsx
+++ b/client/src/containers/third-party/index.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import React, { useMemo } from "react";
+
+import useCookie from "react-use-cookie";
+
+import Script from "next/script";
+
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Markdown } from "@/components/ui/markdown";
+
+// import Cookies from "components/cookies";
+
+const ThirdParty: React.FC = () => {
+  const t = useTranslations();
+  const [consentCookie, setConsentCookie] = useCookie("consent", undefined);
+
+  const consent = useMemo(() => {
+    if (consentCookie === "true") return true;
+    if (consentCookie === "false") return false;
+    return undefined;
+  }, [consentCookie]);
+
+  const handleCookieClick = (c: boolean) => {
+    setConsentCookie(String(c));
+  };
+
+  return (
+    <>
+      {consent && (
+        <>
+          {/* Third Party Script needing cookies */}
+          {/* Global site tag (gtag.js) - Google Analytics */}
+          <Script id="fullstory" strategy="lazyOnload">
+            {`
+              window['_fs_host'] = 'fullstory.com';
+              window['_fs_script'] = 'edge.fullstory.com/s/fs.js';
+              window['_fs_org'] = 'o-206Z64-na1';
+              window['_fs_namespace'] = 'FS';
+              !function(m,n,e,t,l,o,g,y){var s,f,a=function(h){
+              return!(h in m)||(m.console&&m.console.log&&m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].'),!1)}(e)
+              ;function p(b){var h,d=[];function j(){h&&(d.forEach((function(b){var d;try{d=b[h[0]]&&b[h[0]](h[1])}catch(h){return void(b[3]&&b[3](h))}
+              d&&d.then?d.then(b[2],b[3]):b[2]&&b[2](d)})),d.length=0)}function r(b){return function(d){h||(h=[b,d],j())}}return b(r(0),r(1)),{
+              then:function(b,h){return p((function(r,i){d.push([b,h,r,i]),j()}))}}}a&&(g=m[e]=function(){var b=function(b,d,j,r){function i(i,c){
+              h(b,d,j,i,c,r)}r=r||2;var c,u=/Async$/;return u.test(b)?(b=b.replace(u,""),"function"==typeof Promise?new Promise(i):p(i)):h(b,d,j,c,c,r)}
+              ;function h(h,d,j,r,i,c){return b._api?b._api(h,d,j,r,i,c):(b.q&&b.q.push([h,d,j,r,i,c]),null)}return b.q=[],b}(),y=function(b){function h(h){
+              "function"==typeof h[4]&&h[4](new Error(b))}var d=g.q;if(d){for(var j=0;j<d.length;j++)h(d[j]);d.length=0,d.push=h}},function(){
+              (o=n.createElement(t)).async=!0,o.crossOrigin="anonymous",o.src="https://"+l,o.onerror=function(){y("Error loading "+l)}
+              ;var b=n.getElementsByTagName(t)[0];b&&b.parentNode?b.parentNode.insertBefore(o,b):n.head.appendChild(o)}(),function(){function b(){}
+              function h(b,h,d){g(b,h,d,1)}function d(b,d,j){h("setProperties",{type:b,properties:d},j)}function j(b,h){d("user",b,h)}function r(b,h,d){j({
+              uid:b},d),h&&j(h,d)}g.identify=r,g.setUserVars=j,g.identifyAccount=b,g.clearUserCookie=b,g.setVars=d,g.event=function(b,d,j){h("trackEvent",{
+              name:b,properties:d},j)},g.anonymize=function(){r(!1)},g.shutdown=function(){h("shutdown")},g.restart=function(){h("restart")},
+              g.log=function(b,d){h("log",{level:b,msg:d})},g.consent=function(b){h("setIdentity",{consent:!arguments.length||b})}}(),s="fetch",
+              f="XMLHttpRequest",g._w={},g._w[f]=m[f],g._w[s]=m[s],m[s]&&(m[s]=function(){return g._w[s].apply(this,arguments)}),g._v="2.0.0")
+              }(window,document,window._fs_namespace,"script",window._fs_script);
+          `}
+          </Script>
+        </>
+      )}
+
+      <Dialog open={consent === undefined}>
+        <DialogContent className="max-w-3xl">
+          <DialogTitle className="text-2xl">{t("content-title")}</DialogTitle>
+          <DialogDescription className="sr-only">{t("consent-message")}</DialogDescription>
+          <Markdown className="prose-base">{t("consent-message")}</Markdown>
+          <DialogFooter className="justify-end">
+            <Button
+              size="lg"
+              onClick={() => {
+                handleCookieClick(true);
+              }}
+            >
+              {t("accept")}
+            </Button>
+            <Button
+              size="lg"
+              variant="secondary"
+              onClick={() => {
+                handleCookieClick(false);
+              }}
+            >
+              {t("reject")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default ThirdParty;

--- a/client/src/i18n/translations/en.json
+++ b/client/src/i18n/translations/en.json
@@ -264,5 +264,5 @@
   "accept": "Accept",
   "reject": "Reject",
   "content-title": "Cookies consent",
-  "consent-message": "AmazoniaForever360+ uses cookies that collect personal data in order to measure the audience and analyze the needs of our users, with the goal of improving the platform. \n If you accept the use of cookies, data will be shared with Fullstory. If you refuse, no cookies will be set and no data collection will occur."
+  "consent-message": "AmazoniaForever360+ uses cookies that collect personal data in order to measure the audience and analyze the needs of our users, with the goal of improving the platform. \n\n If you accept the use of cookies, data will be shared with [Fullstory](https://www.fullstory.com/). If you refuse, no cookies will be set and no data collection will occur."
 }

--- a/client/src/i18n/translations/en.json
+++ b/client/src/i18n/translations/en.json
@@ -260,5 +260,9 @@
   "indicators": "Indicators",
   "edit": "Edit",
   "view": "View",
-  "save": "Save"
+  "save": "Save",
+  "accept": "Accept",
+  "reject": "Reject",
+  "content-title": "Cookies consent",
+  "consent-message": "AmazoniaForever360+ uses cookies that collect personal data in order to measure the audience and analyze the needs of our users, with the goal of improving the platform. \n If you accept the use of cookies, data will be shared with Fullstory. If you refuse, no cookies will be set and no data collection will occur."
 }

--- a/client/src/i18n/translations/es.json
+++ b/client/src/i18n/translations/es.json
@@ -264,5 +264,5 @@
   "accept": "Aceptar",
   "reject": "Rechazar",
   "content-title": "Consentimiento de cookies",
-  "consent-message": "AmazoniaForever360+ utiliza cookies que recopilan datos personales con el fin de medir la audiencia y analizar las necesidades de nuestros usuarios, con el objetivo de mejorar la plataforma. \n Si acepta el uso de cookies, los datos se compartirán con Fullstory. Si rechaza, no se establecerán cookies y no se recopilarán datos."
+  "consent-message": "AmazoniaForever360+ utiliza cookies que recopilan datos personales con el fin de medir la audiencia y analizar las necesidades de nuestros usuarios, con el objetivo de mejorar la plataforma. \n\n Si acepta el uso de cookies, los datos se compartirán con [Fullstory](https://www.fullstory.com/). Si rechaza, no se establecerán cookies y no se recopilarán datos."
 }

--- a/client/src/i18n/translations/es.json
+++ b/client/src/i18n/translations/es.json
@@ -260,5 +260,9 @@
   "indicators": "Indicadores",
   "edit": "Editar",
   "view": "Ver",
-  "save": "Guardar"
+  "save": "Guardar",
+  "accept": "Aceptar",
+  "reject": "Rechazar",
+  "content-title": "Consentimiento de cookies",
+  "consent-message": "AmazoniaForever360+ utiliza cookies que recopilan datos personales con el fin de medir la audiencia y analizar las necesidades de nuestros usuarios, con el objetivo de mejorar la plataforma. \n Si acepta el uso de cookies, los datos se compartirán con Fullstory. Si rechaza, no se establecerán cookies y no se recopilarán datos."
 }

--- a/client/src/i18n/translations/pt.json
+++ b/client/src/i18n/translations/pt.json
@@ -264,5 +264,5 @@
   "accept": "Aceitar",
   "reject": "Rejeitar",
   "content-title": "Consentimento de cookies",
-  "consent-message": "AmazoniaForever360+ usa cookies que coletam dados pessoais para medir a audiência e analisar as necessidades de nossos usuários, com o objetivo de melhorar a plataforma. \n Se você aceitar o uso de cookies, os dados serão compartilhados com a Fullstory. Se você rejeitar, nenhum cookie será definido e nenhuma coleta de dados ocorrerá."
+  "consent-message": "AmazoniaForever360+ usa cookies que coletam dados pessoais para medir a audiência e analisar as necessidades de nossos usuários, com o objetivo de melhorar a plataforma. \n\n Se você aceitar o uso de cookies, os dados serão compartilhados com a [Fullstory](https://www.fullstory.com/). Se você rejeitar, nenhum cookie será definido e nenhuma coleta de dados ocorrerá."
 }

--- a/client/src/i18n/translations/pt.json
+++ b/client/src/i18n/translations/pt.json
@@ -260,5 +260,9 @@
   "indicators": "Indicadores",
   "edit": "Editar",
   "view": "Ver",
-  "save": "Salvar"
+  "save": "Salvar",
+  "accept": "Aceitar",
+  "reject": "Rejeitar",
+  "content-title": "Consentimento de cookies",
+  "consent-message": "AmazoniaForever360+ usa cookies que coletam dados pessoais para medir a audiência e analisar as necessidades de nossos usuários, com o objetivo de melhorar a plataforma. \n Se você aceitar o uso de cookies, os dados serão compartilhados com a Fullstory. Se você rejeitar, nenhum cookie será definido e nenhuma coleta de dados ocorrerá."
 }


### PR DESCRIPTION
This pull request introduces a cookie consent dialog for third-party scripts, ensuring user consent before loading tracking scripts like FullStory. The implementation includes a new `ThirdParty` component, updates to the main layout to use this component, and new translations for the consent dialog in English, Spanish, and Portuguese.

**Cookie Consent and Third-Party Script Management:**

* Added a new `ThirdParty` component (`client/src/containers/third-party/index.tsx`) that displays a cookie consent dialog and only loads the FullStory tracking script if the user consents.
* Updated the main layout (`client/src/app/[locale]/(app)/layout.tsx`) to remove the inline FullStory script and instead render the new `ThirdParty` component after the main content. ([client/src/app/[locale]/(app)/layout.tsxL7-R14](diffhunk://#diff-46cac152ca45fbefd32d13a28c4daa3adf88900e720cd2e4f09dfd51b27e0e95L7-R14), [client/src/app/[locale]/(app)/layout.tsxR87-L115](diffhunk://#diff-46cac152ca45fbefd32d13a28c4daa3adf88900e720cd2e4f09dfd51b27e0e95R87-L115))

**Internationalization:**

* Added new translation keys and consent dialog text to English, Spanish, and Portuguese translation files to support the cookie consent dialog. [[1]](diffhunk://#diff-6e769d175a52cf1c8ed7455bb8552e1e03a8f7f1edd3a0f58d43a12b53118bdfL263-R267) [[2]](diffhunk://#diff-054613f71c6705e65481113adfb1f316932d852f3771dccb716168dbcddf9be2L263-R267) [[3]](diffhunk://#diff-7730ca396e188a06252899ecd50484ee49e0f8211dd596598368c06a026482d6L263-R267)