### PR TITLE
Lists: clear all also collapse the list

### DIFF
--- a/client/src/containers/report/grid/footer/clear.tsx
+++ b/client/src/containers/report/grid/footer/clear.tsx
@@ -9,6 +9,7 @@ import {
   useSyncGridDatasets,
   selectedFiltersViewAtom,
   useSyncGridSelectedDataset,
+  indicatorsExpandAtom,
 } from "@/app/store";
 
 import { Button } from "@/components/ui/button";
@@ -18,12 +19,14 @@ export default function GridClear() {
   const [gridDatasets, setGridDatasets] = useSyncGridDatasets();
   const setSelectedFiltersView = useSetAtom(selectedFiltersViewAtom);
   const [, setGridSelectedDataset] = useSyncGridSelectedDataset();
+  const setIndicatorsExpand = useSetAtom(indicatorsExpandAtom);
 
   const handleClick = useCallback(() => {
     setSelectedFiltersView(false);
     setGridDatasets([]);
     setGridSelectedDataset(null);
-  }, [setGridDatasets, setSelectedFiltersView, setGridSelectedDataset]);
+    setIndicatorsExpand({});
+  }, [setGridDatasets, setSelectedFiltersView, setGridSelectedDataset, setIndicatorsExpand]);
 
   useEffect(() => {
     if (gridDatasets.length === 0) {

--- a/client/src/containers/report/indicators/footer/index.tsx
+++ b/client/src/containers/report/indicators/footer/index.tsx
@@ -48,6 +48,7 @@ export default function IndicatorsFooter() {
 
   const handleClear = () => {
     setIndicators(null);
+    setIndicatorsExpand({});
   };
 
   return (

--- a/client/src/containers/results/sidebar/indicators/footer/index.tsx
+++ b/client/src/containers/results/sidebar/indicators/footer/index.tsx
@@ -50,9 +50,10 @@ export default function SidebarIndicatorsFooter() {
   const handleClear = useCallback(() => {
     if (!!topics?.length) {
       setTopics([]);
+      setIndicatorsExpand({});
       return;
     }
-  }, [topics, setTopics]);
+  }, [topics, setTopics, setIndicatorsExpand]);
 
   return (
     <div className="flex items-center justify-between">


### PR DESCRIPTION
This pull request introduces improvements to how indicator expansion state is managed and cleared across multiple footer components in the reporting and results sections. The main change is the addition of logic to reset the indicator expansion state (`indicatorsExpandAtom`) when clearing datasets, indicators, or topics, ensuring a consistent UI state.

**Indicator expansion state management:**

* Added `indicatorsExpandAtom` to the imports in `clear.tsx` and updated the clear logic in `GridClear` to reset indicator expansion state when clearing grid datasets. [[1]](diffhunk://#diff-b5fa3328a3a8cc0f0c46cc28485cfaef4385948278bedb8d0143e04b61f705e6R12) [[2]](diffhunk://#diff-b5fa3328a3a8cc0f0c46cc28485cfaef4385948278bedb8d0143e04b61f705e6R22-R29)
* Updated the clear handler in `IndicatorsFooter` to reset indicator expansion state when clearing indicators.
* Updated the clear handler in `SidebarIndicatorsFooter` to reset indicator expansion state when clearing topics.