### PR TITLE
Legend: reorder

### DIFF
--- a/client/src/containers/report/map/legend/item.tsx
+++ b/client/src/containers/report/map/legend/item.tsx
@@ -19,6 +19,7 @@ import OpacityControl from "@/components/map/legend/controls/opacity";
 import RemoveControl from "@/components/map/legend/controls/remove";
 import { FeatureLegend } from "@/components/map/legend/types/feature";
 import { ImageryLegend } from "@/components/map/legend/types/imagery";
+import { Button } from "@/components/ui/button";
 
 export const LegendItem = ({ id }: { id: Indicator["id"] }) => {
   const locale = useLocale();
@@ -81,27 +82,29 @@ export const LegendItem = ({ id }: { id: Indicator["id"] }) => {
 
   return (
     <div className="space-y-1 p-4">
-      <header className="-ml-4 flex justify-between gap-2">
-        <div className="flex items-center gap-1 pl-2">
-          <div>
-            <button
+      <header className="flex justify-between gap-2 pl-1">
+        <div className="relative flex pl-2">
+          <div className="absolute right-full top-0 -mr-1.5">
+            <Button
+              variant="ghost"
               type="button"
               aria-label="Move layer up"
-              className="flex items-center justify-center"
+              className="flex h-6 w-6 items-center justify-center p-0"
               onClick={() => handleChangeOrder(id, 1)}
             >
-              <LuChevronUp className="h-3 w-3 text-foreground" />
-            </button>
-            <button
+              <LuChevronUp className="h-3 w-3" />
+            </Button>
+            <Button
+              variant="ghost"
               type="button"
               aria-label="Move layer down"
-              className="flex items-center justify-center"
+              className="flex h-6 w-6 items-center justify-center p-0"
               onClick={() => handleChangeOrder(id, -1)}
             >
-              <LuChevronDown className="h-3 w-3 text-foreground" />
-            </button>
+              <LuChevronDown className="h-3 w-3" />
+            </Button>
           </div>
-          <h3 className="text-xs font-semibold text-foreground">{name}</h3>
+          <h3 className="mt-1 text-xs font-semibold text-foreground">{name}</h3>
         </div>
 
         <ul className="flex items-center gap-1">
@@ -136,7 +139,7 @@ export const LegendItem = ({ id }: { id: Indicator["id"] }) => {
         </ul>
       </header>
 
-      <div className="pl-2">{LEGEND}</div>
+      <div className="pl-3">{LEGEND}</div>
     </div>
   );
 };


### PR DESCRIPTION
This pull request adds functionality to allow users to reorder map legend items by moving layers up or down directly in the UI. The changes introduce new buttons for this purpose and update the layout for better usability.

**UI Enhancements:**

* Added up and down arrow buttons (`LuChevronUp`, `LuChevronDown`) to each legend item for moving layers up or down in the order. [[1]](diffhunk://#diff-aa1b97602e4a01e6c9ac51b75f0442b75bef36d48f1c6daa78faacb516a5f32cL1-R4) [[2]](diffhunk://#diff-aa1b97602e4a01e6c9ac51b75f0442b75bef36d48f1c6daa78faacb516a5f32cR55-R105)
* Updated the legend item layout for improved spacing and alignment, including left padding adjustments. [[1]](diffhunk://#diff-aa1b97602e4a01e6c9ac51b75f0442b75bef36d48f1c6daa78faacb516a5f32cR55-R105) [[2]](diffhunk://#diff-aa1b97602e4a01e6c9ac51b75f0442b75bef36d48f1c6daa78faacb516a5f32cL95-R139)

**Functionality:**

* Implemented the `handleChangeOrder` callback to swap the positions of indicators in the legend when the arrow buttons are clicked, ensuring the order updates correctly and remains within bounds.