### PR TITLE
Locale: correct typed. Help links by locale

### DIFF
--- a/client/src/app/[locale]/(app)/layout.tsx
+++ b/client/src/app/[locale]/(app)/layout.tsx
@@ -5,7 +5,7 @@ import { Metadata } from "next";
 import { Montserrat } from "next/font/google";
 import { notFound } from "next/navigation";
 
-import { hasLocale, NextIntlClientProvider } from "next-intl";
+import { hasLocale, Locale, NextIntlClientProvider } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
 import RootHead from "@/app/head";
@@ -22,7 +22,7 @@ import "@/styles/globals.css";
 import "@/styles/grid-layout.css";
 import "react-resizable/css/styles.css";
 
-type Params = Promise<{ locale: string }>;
+type Params = Promise<{ locale: Locale }>;
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({

--- a/client/src/app/[locale]/(app)/page.tsx
+++ b/client/src/app/[locale]/(app)/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 
+import { Locale } from "next-intl";
 import { getTranslations } from "next-intl/server";
 
 import Footer from "@/containers/footer";
@@ -13,7 +14,7 @@ import KeyFeaturesGrid from "@/containers/home/key-features-grid";
 import KeyFeaturesReport from "@/containers/home/key-features-report";
 import Partners from "@/containers/home/partners";
 
-type Params = Promise<{ locale: string }>;
+type Params = Promise<{ locale: Locale }>;
 
 export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
   const { locale } = await params;

--- a/client/src/app/[locale]/(app)/report/(new)/grid/page.tsx
+++ b/client/src/app/[locale]/(app)/report/(new)/grid/page.tsx
@@ -1,10 +1,11 @@
 import { Metadata } from "next";
 
+import { Locale } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
 import ReportGrid from "@/containers/report/grid";
 
-type Params = Promise<{ locale: string }>;
+type Params = Promise<{ locale: Locale }>;
 
 export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
   const { locale } = await params;

--- a/client/src/app/[locale]/(app)/report/(new)/indicators/page.tsx
+++ b/client/src/app/[locale]/(app)/report/(new)/indicators/page.tsx
@@ -1,10 +1,11 @@
 import { Metadata } from "next";
 
+import { Locale } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
 import ReportIndicators from "@/containers/report/indicators";
 
-type Params = Promise<{ locale: string }>;
+type Params = Promise<{ locale: Locale }>;
 
 export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
   const { locale } = await params;

--- a/client/src/app/[locale]/(app)/report/(new)/page.tsx
+++ b/client/src/app/[locale]/(app)/report/(new)/page.tsx
@@ -1,10 +1,11 @@
 import { Metadata } from "next";
 
+import { Locale } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
 import ReportLocation from "@/containers/report/location";
 
-type Params = Promise<{ locale: string }>;
+type Params = Promise<{ locale: Locale }>;
 
 export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
   const { locale } = await params;

--- a/client/src/app/[locale]/(app)/report/(results)/results/page.tsx
+++ b/client/src/app/[locale]/(app)/report/(results)/results/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 
 import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
+import { Locale } from "next-intl";
 import { getTranslations } from "next-intl/server";
 
 // import { getSearchQueryOptions } from "@/lib/search";
@@ -10,7 +11,7 @@ import ReportResultsHeader from "@/containers/header/results";
 import ReportResultsContent from "@/containers/results/content";
 import ReportResultsSidebar from "@/containers/results/sidebar";
 
-type Params = Promise<{ locale: string }>;
+type Params = Promise<{ locale: Locale }>;
 
 export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
   const { locale } = await params;

--- a/client/src/app/[locale]/layout.tsx
+++ b/client/src/app/[locale]/layout.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 
 import { notFound } from "next/navigation";
 
-import { hasLocale } from "next-intl";
+import { hasLocale, Locale } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
 import LayoutProviders from "@/app/layout-providers";
@@ -14,7 +14,7 @@ import "@/styles/globals.css";
 import "@/styles/grid-layout.css";
 import "react-resizable/css/styles.css";
 
-type Params = Promise<{ locale: string }>;
+type Params = Promise<{ locale: Locale }>;
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({

--- a/client/src/app/[locale]/webshot/layout.tsx
+++ b/client/src/app/[locale]/webshot/layout.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 import { Montserrat } from "next/font/google";
 import { notFound } from "next/navigation";
 
-import { hasLocale, NextIntlClientProvider } from "next-intl";
+import { hasLocale, Locale, NextIntlClientProvider } from "next-intl";
 import { setRequestLocale } from "next-intl/server";
 
 import RootHead from "@/app/head";
@@ -15,7 +15,7 @@ import "@/styles/globals.css";
 import "@/styles/grid-layout.css";
 import "react-resizable/css/styles.css";
 
-type Params = Promise<{ locale: string }>;
+type Params = Promise<{ locale: Locale }>;
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({

--- a/client/src/app/layout-providers.tsx
+++ b/client/src/app/layout-providers.tsx
@@ -2,14 +2,13 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Provider as JotaiProvider } from "jotai";
+import { Locale } from "next-intl";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 
 import { MediaContextProvider } from "@/containers/media";
 import { ArcGISProvider } from "@/containers/providers/arcgis";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
-
-import { Locale } from "@/i18n/types";
 
 function makeQueryClient() {
   return new QueryClient({

--- a/client/src/app/next-intl-provider.tsx
+++ b/client/src/app/next-intl-provider.tsx
@@ -2,11 +2,11 @@
 
 import { PropsWithChildren } from "react";
 
-import { AbstractIntlMessages, NextIntlClientProvider } from "next-intl";
+import { AbstractIntlMessages, Locale, NextIntlClientProvider } from "next-intl";
 
 type NextIntlProviderProps = PropsWithChildren & {
   messages: AbstractIntlMessages;
-  locale: string;
+  locale: Locale;
 };
 
 const NextIntlProvider = ({ messages, locale, children }: NextIntlProviderProps) => {

--- a/client/src/components/map/controls/opacity.tsx
+++ b/client/src/components/map/controls/opacity.tsx
@@ -14,7 +14,6 @@ import { Tooltip, TooltipTrigger, TooltipArrow, TooltipContent } from "@/compone
 const OpacityControl = ({
   value,
   onValueChange,
-  labelSlug = "grid-report-map-legend-layer-opacity",
   triggerClassName,
 }: {
   value: number;
@@ -47,7 +46,7 @@ const OpacityControl = ({
           onClick={(e) => e.stopPropagation()}
         >
           <div className="flex w-72 flex-col space-y-2 rounded-lg bg-white px-4 py-2 shadow-md">
-            <div className="text-sm">{t(labelSlug)}</div>
+            <div className="text-sm">{t("grid-report-map-legend-layer-opacity")}</div>
             <div className="py-2">
               <Slider
                 min={0}

--- a/client/src/containers/header/language-selector/desktop.tsx
+++ b/client/src/containers/header/language-selector/desktop.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParams } from "next/navigation";
 
-import { useLocale } from "next-intl";
+import { Locale, useLocale } from "next-intl";
 
 import { LOCALES, localeLabelsShort, localeLabelsLong } from "@/lib/locales";
 import { cn } from "@/lib/utils";
@@ -16,16 +16,15 @@ import {
 } from "@/components/ui/select";
 
 import { useRouter, usePathname } from "@/i18n/navigation";
-import { Locale } from "@/i18n/types";
 
 const LanguageSelector = () => {
-  const locale = useLocale() as Locale;
+  const locale = useLocale();
 
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams()?.toString();
 
-  const onSelectLocale = (nextLocale: string) => {
+  const onSelectLocale = (nextLocale: Locale) => {
     const path = `${pathname}${searchParams ? `?${searchParams}` : ""}`;
     router.push(path, { locale: nextLocale });
   };

--- a/client/src/containers/header/language-selector/mobile.tsx
+++ b/client/src/containers/header/language-selector/mobile.tsx
@@ -8,10 +8,9 @@ import { LOCALES, localeLabelsLong } from "@/lib/locales";
 import { cn } from "@/lib/utils";
 
 import { Link, usePathname } from "@/i18n/navigation";
-import { Locale } from "@/i18n/types";
 
 const MobileLanguageSelector = () => {
-  const locale = useLocale() as Locale;
+  const locale = useLocale();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 

--- a/client/src/containers/header/results/share.tsx
+++ b/client/src/containers/header/results/share.tsx
@@ -24,7 +24,7 @@ export default function ShareReport() {
 
   const [currentUrl, setCurrentUrl] = useState<string>("");
 
-  const [shareLinkBtnText, setShareLinkBtnText] = useState("copy");
+  const [shareLinkBtnText, setShareLinkBtnText] = useState<"copy" | "copied">("copy");
   useEffect(() => {
     setCurrentUrl(window.location.href);
   }, [pathname]);

--- a/client/src/containers/providers/arcgis.tsx
+++ b/client/src/containers/providers/arcgis.tsx
@@ -4,12 +4,11 @@ import { PropsWithChildren, useMemo } from "react";
 
 import esriConfig from "@arcgis/core/config";
 import { setLocale } from "@arcgis/core/intl";
+import { Locale } from "next-intl";
 
 import { env } from "@/env.mjs";
 
 import { DATASETS } from "@/constants/datasets";
-
-import { Locale } from "@/i18n/types";
 
 export const ArcGISProvider = ({
   locale,

--- a/client/src/containers/report/location/desktop.tsx
+++ b/client/src/containers/report/location/desktop.tsx
@@ -3,7 +3,7 @@
 import { useSearchParams } from "next/navigation";
 
 import { LucideHelpCircle } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { LuDatabase } from "react-icons/lu";
 
 import { cn } from "@/lib/utils";
@@ -16,9 +16,16 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 
 import { Link } from "@/i18n/navigation";
 
+const HELP_LINKS = {
+  en: "https://rise.articulate.com/share/GWlgAGqnPZihWgXVpLCGge4Pjjk9k2Wo#/?locale=en-us",
+  es: "https://rise.articulate.com/share/GWlgAGqnPZihWgXVpLCGge4Pjjk9k2Wo#/",
+  pt: "https://rise.articulate.com/share/GWlgAGqnPZihWgXVpLCGge4Pjjk9k2Wo#/?locale=pt-br",
+};
+
 export default function ReportLocationDesktop() {
   const searchParams = useSearchParams();
 
+  const locale = useLocale();
   const t = useTranslations();
 
   const SIDEBAR_CARDS = [
@@ -45,7 +52,7 @@ export default function ReportLocationDesktop() {
               <div className="flex max-h-[calc(100vh_-_(64px_+_40px_+_28px))] grow flex-col">
                 <div className="relative flex max-h-full grow flex-col overflow-hidden">
                   <a
-                    href="https://rise.articulate.com/share/GWlgAGqnPZihWgXVpLCGge4Pjjk9k2Wo#/"
+                    href={HELP_LINKS[locale]}
                     target="_blank"
                     rel="noreferrer noopener"
                     className="absolute right-6 top-6 z-10"

--- a/client/src/containers/results/header/title.tsx
+++ b/client/src/containers/results/header/title.tsx
@@ -3,7 +3,7 @@
 import { ChangeEvent, useCallback, useMemo, useRef, useState } from "react";
 
 import { LucideHelpCircle } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { LuPen, LuCheck, LuX } from "react-icons/lu";
 
 import { cn } from "@/lib/utils";
@@ -13,8 +13,16 @@ import { useSyncLocation } from "@/app/store";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
+const HELP_LINKS = {
+  en: "https://rise.articulate.com/share/DzHpFspTQWmMCeeoMXA2_6v5Zljl-b7i#/?locale=en-us",
+  es: "https://rise.articulate.com/share/DzHpFspTQWmMCeeoMXA2_6v5Zljl-b7i#/",
+  pt: "https://rise.articulate.com/share/DzHpFspTQWmMCeeoMXA2_6v5Zljl-b7i#/?locale=pt-br",
+};
+
 export default function EditableHeader({ value = "Selected area" }: { value?: string }) {
+  const locale = useLocale();
   const t = useTranslations();
+
   const [location, setLocation] = useSyncLocation();
   const [editMode, setEditMode] = useState(false);
   const [title, setTitle] = useState(location?.custom_title ?? value);
@@ -128,11 +136,7 @@ export default function EditableHeader({ value = "Selected area" }: { value?: st
             </header>
           )}
 
-          <a
-            href="https://rise.articulate.com/share/DzHpFspTQWmMCeeoMXA2_6v5Zljl-b7i#/"
-            target="_blank"
-            rel="noreferrer noopener"
-          >
+          <a href={HELP_LINKS[locale]} target="_blank" rel="noreferrer noopener">
             <Button size="sm" variant="outline" type="button" className="gap-2">
               <LucideHelpCircle className="h-4 w-4 text-secondary-foreground" />
 

--- a/client/src/i18n/types.ts
+++ b/client/src/i18n/types.ts
@@ -1,1 +1,10 @@
-export type Locale = "en" | "es" | "pt";
+import { routing } from "@/i18n/routing";
+
+import messages from "./translations/en.json";
+declare module "next-intl" {
+  interface AppConfig {
+    Locale: (typeof routing.locales)[number];
+    Messages: typeof messages;
+    // Formats: typeof formats;
+  }
+}

--- a/client/src/lib/locales.ts
+++ b/client/src/lib/locales.ts
@@ -1,4 +1,6 @@
-export const LOCALES = ["en", "es", "pt"] as const;
+import { routing } from "@/i18n/routing";
+
+export const LOCALES = routing.locales;
 export const localeLabelsShort: Record<(typeof LOCALES)[number], string> = {
   en: "EN",
   es: "ES",


### PR DESCRIPTION
This pull request updates the handling of locales across the codebase to use the `Locale` type from `next-intl` rather than a custom type, and ensures locale values are consistently derived from the centralized `routing.locales` configuration. It also improves the way locale-specific help links are generated in the UI, and tightens type safety for certain component props. These changes help standardize locale management and improve maintainability.

**Locale type migration and centralization:**

* Replaced custom `Locale` type and manual locale arrays with the `Locale` type from `next-intl` and values from `routing.locales` throughout the app, including in all page and layout files, providers, and UI components. ([client/src/app/[locale]/(app)/layout.tsxL8-R8](diffhunk://#diff-46cac152ca45fbefd32d13a28c4daa3adf88900e720cd2e4f09dfd51b27e0e95L8-R8), [client/src/app/[locale]/(app)/layout.tsxL25-R25](diffhunk://#diff-46cac152ca45fbefd32d13a28c4daa3adf88900e720cd2e4f09dfd51b27e0e95L25-R25), [client/src/app/[locale]/(app)/page.tsxR3](diffhunk://#diff-cef154db91346a382eb2893ead8d65826239b0468c165c32f5eb008ba7706a5dR3), [client/src/app/[locale]/(app)/page.tsxL16-R17](diffhunk://#diff-cef154db91346a382eb2893ead8d65826239b0468c165c32f5eb008ba7706a5dL16-R17), [client/src/app/[locale]/(app)/report/(new)/grid/page.tsxR3-R8](diffhunk://#diff-2a73fb09866f3e219efbfe8c4920915f9a7a9e49ef4789a10232ce3fa7c046aeR3-R8), Fe64bd67L7R7, [client/src/app/[locale]/(app)/report/(new)/indicators/page.tsxR3-R8](diffhunk://#diff-9c36d92e418061649e5900106dc5bac32876c60ad0b1bb77bc2f267a13e10288R3-R8), Ff885f6bL7R7, [client/src/app/[locale]/(app)/report/(new)/page.tsxR3-R8](diffhunk://#diff-ca01d39f6779e790f0c11d001a3313491340e58faaf2d3a6af94327a3ff58756R3-R8), Fbe82e14L7R7, [client/src/app/[locale]/(app)/report/(results)/results/page.tsxR4](diffhunk://#diff-9114714b0536f0c4f56da311bc71534a1bebf77fdd304f88057165530fe6995cR4), [client/src/app/[locale]/(app)/report/(results)/results/page.tsxL13-R14](diffhunk://#diff-9114714b0536f0c4f56da311bc71534a1bebf77fdd304f88057165530fe6995cL13-R14), [client/src/app/[locale]/layout.tsxL5-R5](diffhunk://#diff-83b24ceb31425ff7de4525ad500868a0fbf27be35d07623039b4976871d3d6eaL5-R5), [client/src/app/[locale]/layout.tsxL17-R17](diffhunk://#diff-83b24ceb31425ff7de4525ad500868a0fbf27be35d07623039b4976871d3d6eaL17-R17), [client/src/app/[locale]/webshot/layout.tsxL6-R6](diffhunk://#diff-a96f64a457c02b5671d083a6566b01305f1329a579cb2958c0fedde07f5bd129L6-R6), [client/src/app/[locale]/webshot/layout.tsxL18-R18](diffhunk://#diff-a96f64a457c02b5671d083a6566b01305f1329a579cb2958c0fedde07f5bd129L18-R18), [[1]](diffhunk://#diff-7258c0e3e4181f5bcc95600529b7ff8f63c5743032c205f9c5e7844658b55df6R5-L13) [[2]](diffhunk://#diff-5992c9afffeb08ffd47b67df0ae36668754e876f77020e7ab34ed9a725b4b6eeL5-R9) [[3]](diffhunk://#diff-bc372c038ddc56a9590f524bfb4c9091fd0eaafc94311409cc80feb124eaa0bfL5-R5) [[4]](diffhunk://#diff-bc372c038ddc56a9590f524bfb4c9091fd0eaafc94311409cc80feb124eaa0bfL19-R27) [[5]](diffhunk://#diff-b9c9f560bd1b3fc7a9a90ae9a994c1e5b025b56391e6973c912b181499fdf5e4L11-R13) [[6]](diffhunk://#diff-8f88b9e6fa1b6ff5f1c408d6896774926f9964b924e146f1d6348ba789debb55R7-L13) [[7]](diffhunk://#diff-67b62cb27983b8201768687e4916aa6404b557fdb4037f4f0157cb071dcd107bL1-R10) [[8]](diffhunk://#diff-c8b25626b4d4921ec034295fea3baa744b1369595dd395210129302677bf03ffL1-R3)

**Locale-aware help links in UI:**

* Updated help links in `ReportLocationDesktop` and `EditableHeader` to dynamically select the correct link based on the current locale, using new locale-to-link mappings. [[1]](diffhunk://#diff-ea5dc268aebd3b58da4be3d64be88f2e9b03a62bcac4b09d5294b2a77e866148L6-R6) [[2]](diffhunk://#diff-ea5dc268aebd3b58da4be3d64be88f2e9b03a62bcac4b09d5294b2a77e866148R19-R28) [[3]](diffhunk://#diff-ea5dc268aebd3b58da4be3d64be88f2e9b03a62bcac4b09d5294b2a77e866148L48-R55) [[4]](diffhunk://#diff-3ca99171bed509b77e3f3d39429dad774d9e39a6d883a34faeb8636026149498L6-R6) [[5]](diffhunk://#diff-3ca99171bed509b77e3f3d39429dad774d9e39a6d883a34faeb8636026149498R16-R25) [[6]](diffhunk://#diff-3ca99171bed509b77e3f3d39429dad774d9e39a6d883a34faeb8636026149498L131-R139)

**Type safety improvements:**

* Changed the state type for the share link button text in `ShareReport` to a union type, improving type safety.

**Minor UI and code consistency fixes:**

* Refactored the opacity control label to use a hardcoded translation key rather than a variable, simplifying the code. [[1]](diffhunk://#diff-eeb5d484bcce3d5a13bc96c740ad4aec6251aa6e0cdf2352f576a26f3dc3a384L17) [[2]](diffhunk://#diff-eeb5d484bcce3d5a13bc96c740ad4aec6251aa6e0cdf2352f576a26f3dc3a384L50-R49)

These changes collectively improve locale management, user experience, and code maintainability.