### PR TITLE
fix(deps): resolve GHSA-wf6x-7x77-mvgw — override immutable@4.3.8 via sass

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -190,7 +190,8 @@
       "@auth/core>cookie": "0.7.0",
       "ts-node>diff": "4.0.4",
       "uvu>diff": "5.2.2",
-      "unidiff>diff": "5.2.2"
+      "unidiff>diff": "5.2.2",
+      "sass>immutable": "4.3.8"
     }
   }
 }

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   ts-node>diff: 4.0.4
   uvu>diff: 5.2.2
   unidiff>diff: 5.2.2
+  sass>immutable: 4.3.8
 
 importers:
 
@@ -6282,8 +6283,8 @@ packages:
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
-  immutable@4.3.7:
-    resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
+  immutable@4.3.8:
+    resolution: {integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -17206,7 +17207,7 @@ snapshots:
 
   immediate@3.0.6: {}
 
-  immutable@4.3.7: {}
+  immutable@4.3.8: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -19637,7 +19638,7 @@ snapshots:
   sass@1.77.4:
     dependencies:
       chokidar: 3.6.0
-      immutable: 4.3.7
+      immutable: 4.3.8
       source-map-js: 1.2.1
 
   saxes@6.0.0:


### PR DESCRIPTION
## Summary

- Adds a scoped pnpm override to force `immutable@4.3.8`, fixing the Prototype Pollution vulnerability ([GHSA-wf6x-7x77-mvgw](https://github.com/advisories/GHSA-wf6x-7x77-mvgw))
- `sass@1.77.4` (transitive dep of `@payloadcms/next`) depends on `immutable@^4.0.0` which resolved to the vulnerable `4.3.7`
- `@payloadcms/next@3.79.0` (latest stable) still ships `sass@1.77.4`, so a direct upgrade is not possible

## Test plan

- [x] Verify `pnpm install` succeeds and lockfile resolves `immutable` to `4.3.8`
- [x] Verify `pnpm build` completes without errors
- [x] Confirm the Dependabot alert for GHSA-wf6x-7x77-mvgw is resolved