### PR TITLE
feat(AM-638): display GCF in dedicated "Powered by" section on landing page

### DIFF
--- a/.playwright-mcp/console-2026-04-08T19-56-54-158Z.log
+++ b/.playwright-mcp/console-2026-04-08T19-56-54-158Z.log
@@ -1,0 +1,24 @@
+[     792ms] [ERROR] Failed to load resource: the server responded with a status of 500 (Internal Server Error) @ http://localhost:3000/es:0
+[    1030ms] [INFO] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold @ webpack-internal:///(pages-dir-browser)/./node_modules/.pnpm/react-dom@19.2.1_react@19.2.1/node_modules/react-dom/cjs/react-dom-client.development.js:28004
+[    1133ms] Error: Cannot find module './vendor-chunks/@arcgis+core@4.30.9_@floating-ui+utils@0.2.11.js'
+Require stack:
+- /Users/miguelbarrenecheasanchez/Projects/amazonia-360/client/.next/server/webpack-runtime.js
+- /Users/miguelbarrenecheasanchez/Projects/amazonia-360/client/.next/server/app/(frontend)/[locale]/(app)/page.js
+- /Users/miguelbarrenecheasanchez/Projects/amazonia-360/client/node_modules/.pnpm/next@15.5.13_@babel+core@7.29.0_react-dom@19.2.1_react@19.2.1/node_modules/next/dist/server/require.js
+- /Users/miguelbarrenecheasanchez/Projects/amazonia-360/client/node_modules/.pnpm/next@15.5.13_@babel+core@7.29.0_react-dom@19.2.1_react@19.2.1/node_modules/next/dist/server/load-components.js
+- /Users/miguelbarrenecheasanchez/Projects/amazonia-360/client/node_modules/.pnpm/next@15.5.13_@babel+core@7.29.0_react-dom@19.2.1_react@19.2.1/node_modules/next/dist/build/utils.js
+- /Users/miguelbarrenecheasanchez/Projects/amazonia-360/client/node_modules/.pnpm/next@15.5.13_@babel+core@7.29.0_react-dom@19.2.1_react@19.2.1/node_modules/next/dist/server/dev/static-paths-worker.js
+- /Users/miguelbarrenecheasanchez/Projects/amazonia-360/client/node_modules/.pnpm/next@15.5.13_@babel+core@7.29.0_react-dom@19.2.1_react@19.2.1/node_modules/next/dist/compiled/jest-worker/processChild.js
+    at Function.<anonymous> (node:internal/modules/cjs/loader:1225:15)
+    at <unknown> (file:///Users/miguelbarrenecheasanchez/Projects/amazonia-360/client/node_modules/.pnpm/next@15.5.13_@babel+core@7.29.0_react-dom@19.2.1_react@19.2.1/node_modules/next/dist/server/require-hook.js:57:36)
+    at Function._load (node:internal/modules/cjs/loader:1055:27)
+    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
+    at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)
+    at Module.<anonymous> (node:internal/modules/cjs/loader:1311:12)
+    at mod.require (file:///Users/miguelbarrenecheasanchez/Projects/amazonia-360/client/node_modules/.pnpm/next@15.5.13_@babel+core@7.29.0_react-dom@19.2.1_react@19.2.1/node_modules/next/dist/server/require-hook.js:68:28)
+    at require (node:internal/modules/helpers:136:16)
+    at __webpack_require__.f.require (file:///Users/miguelbarrenecheasanchez/Projects/amazonia-360/client/.next/server/webpack-runtime.js:269:28)
+    at <unknown> (file:///Users/miguelbarrenecheasanchez/Projects/amazonia-360/client/.next/server/webpack-runtime.js:177:40)
+[    1105ms] [LOG] [HMR] connected @ webpack-internal:///(pages-dir-browser)/./node_modules/.pnpm/next@15.5.13_@babel+core@7.29.0_react-dom@19.2.1_react@19.2.1/node_modules/next/dist/client/dev/hot-reloader/pages/websocket.js:45
+[   44037ms] [ERROR] Failed to load resource: the server responded with a status of 500 (Internal Server Error) @ http://localhost:3000/es:0
+[   44080ms] [ERROR] Failed to load resource: the server responded with a status of 500 (Internal Server Error) @ http://localhost:3000/favicon.ico:0

--- a/.playwright-mcp/page-2026-04-08T19-56-55-382Z.yml
+++ b/.playwright-mcp/page-2026-04-08T19-56-55-382Z.yml
@@ -1,0 +1,13 @@
+- generic [active]:
+  - generic [ref=e5] [cursor=pointer]:
+    - button "Open Next.js Dev Tools" [ref=e6]:
+      - img [ref=e7]
+    - generic [ref=e10]:
+      - button "Open issues overlay" [ref=e11]:
+        - generic [ref=e12]:
+          - generic [ref=e13]: "0"
+          - generic [ref=e14]: "1"
+        - generic [ref=e15]: Issue
+      - button "Collapse issues badge" [ref=e16]:
+        - img [ref=e17]
+  - alert [ref=e19]

--- a/client/src/containers/home/partners/index.tsx
+++ b/client/src/containers/home/partners/index.tsx
@@ -72,14 +72,6 @@ const PARTNERS = [
     height: 192,
   },
   {
-    href: "https://www.greenclimate.fund/",
-    src: "/partners/green-climate-fund.avif",
-    alt: "Green Climate Fund",
-    className: "p-1 -top-4",
-    width: 331,
-    height: 192,
-  },
-  {
     href: "https://www.esri.com/",
     src: "/partners/esri.avif",
     alt: "Esri",
@@ -96,6 +88,14 @@ const PARTNERS = [
     height: 192,
   },
 ];
+
+const GCF_PARTNER = {
+  href: "https://www.greenclimate.fund/",
+  src: "/partners/green-climate-fund.avif",
+  alt: "Green Climate Fund",
+  width: 331,
+  height: 192,
+};
 export default function Partners() {
   const t = useTranslations();
 
@@ -133,6 +133,26 @@ export default function Partners() {
               <Partner {...partner} key={`partner-${index}`} />
             ))}
           </ul>
+          <div className="h-px w-full bg-gradient-to-r from-transparent via-blue-300 to-transparent" />
+          <div className="flex items-center justify-center gap-4 pt-6">
+            <p className="text-sm font-semibold uppercase tracking-wide-lg text-blue-400">
+              {t("landing-partners-powered-by")}
+            </p>
+            <a
+              href={GCF_PARTNER.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center"
+            >
+              <Image
+                src={GCF_PARTNER.src}
+                alt={GCF_PARTNER.alt}
+                width={GCF_PARTNER.width}
+                height={GCF_PARTNER.height}
+                className="h-auto max-h-20 w-auto object-contain"
+              />
+            </a>
+          </div>
         </div>
       </div>
     </section>

--- a/client/src/i18n/translations/en.json
+++ b/client/src/i18n/translations/en.json
@@ -35,6 +35,7 @@
   "landing-partners-note": "Powered by",
   "landing-partners-title": "We will not do this alone.",
   "landing-partners-description": "As a regional public good initiated by the IDB Group, AmazoniaForever360+ will seek to build on strong alliances with strategic, data and technology partners.",
+  "landing-partners-powered-by": "Powered by",
   "landing-cta-key": "Start creating your custom report!",
   "landing-cta-title": "Select your area of interest, choose the indicators that matter to you, and generate a personalized report about Amazonia. Explore the data, discover insights, and share your findings.",
   "landing-cta-access": "Access the tool",

--- a/client/src/i18n/translations/es.json
+++ b/client/src/i18n/translations/es.json
@@ -35,6 +35,7 @@
   "landing-partners-note": "Powered by",
   "landing-partners-title": "No lo haremos solos.",
   "landing-partners-description": "Como un bien público regional iniciado por el Grupo BID, AmazoniaForever360+ buscará construir alianzas sólidas con socios estratégicos, de datos y tecnología.",
+  "landing-partners-powered-by": "Powered by",
   "landing-cta-key": "¡Comience a crear su informe personalizado!",
   "landing-cta-title": "Seleccione su área de interés, elija los indicadores que le importan y genere un informe personalizado sobre la Amazonia. Explore los datos, descubra información y comparta sus hallazgos.",
   "landing-cta-access": "Acceder a la herramienta",

--- a/client/src/i18n/translations/pt.json
+++ b/client/src/i18n/translations/pt.json
@@ -35,6 +35,7 @@
   "landing-partners-note": "Powered by",
   "landing-partners-title": "Não faremos isso sozinhos.",
   "landing-partners-description": "Como um bem público regional iniciado pelo Grupo BID, AmazoniaForever360+ buscará construir alianças sólidas com parceiros estratégicos, de dados e tecnologia.",
+  "landing-partners-powered-by": "Powered by",
   "landing-cta-key": "Comece a criar seu relatório personalizado!",
   "landing-cta-title": "Selecione sua área de interesse, escolha os indicadores que importam para você e gere um relatório personalizado sobre a Amazônia. Explore os dados, descubra insights e compartilhe suas descobertas.",
   "landing-cta-access": "Acesse a ferramenta",


### PR DESCRIPTION
## Summary

- Moves the Green Climate Fund (GCF) logo out of the main partners grid into a new dedicated **"Powered by"** section below it
- Adds a decorative gradient divider between the partners list and the new section
- Adds the `landing-partners-powered-by` i18n key to all three locales (`en`, `es`, `pt`)
- Two `.playwright-mcp/` debug artefacts (`console-*.log`, `page-*.yml`) were committed alongside the feature — these should be removed or added to `.gitignore` before merge

## Testing

- [ ] Landing page renders the "Powered by" label and GCF logo beneath the partners grid in all three locales (EN / ES / PT)
- [ ] GCF logo is no longer present inside the main partners grid
- [ ] Gradient divider is visible between the partners list and the "Powered by" row
- [ ] GCF logo link opens `https://www.greenclimate.fund/` in a new tab with `rel="noopener noreferrer"`
- [ ] Logo displays correctly at different viewport sizes (responsive)
- [ ] `.playwright-mcp/` debug files confirmed removed or gitignored before merge
- [ ] `pnpm lint && pnpm check-types` passes in `client/`