### PR TITLE
fix(client): verify email via Payload Local API to bypass basic auth

### DIFF
--- a/client/src/app/(frontend)/[locale]/(app)/auth/verify-email/actions.ts
+++ b/client/src/app/(frontend)/[locale]/(app)/auth/verify-email/actions.ts
@@ -1,6 +1,8 @@
 "use server";
 
-import { sdk } from "@/services/sdk";
+import { getPayload } from "payload";
+
+import config from "@/payload.config";
 
 export type VerifyEmailResult =
   | { success: true }
@@ -12,14 +14,13 @@ export async function verifyEmailAction(token: string): Promise<VerifyEmailResul
   }
 
   try {
-    await sdk.verifyEmail({
-      collection: "users",
-      token,
-    });
+    const payload = await getPayload({ config });
+    await payload.verifyEmail({ collection: "users", token });
     return { success: true };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    const isInvalid = /invalid/i.test(message) || /403/.test(message);
+    const status = (error as { status?: number } | null)?.status;
+    const isInvalid = status === 403 || /invalid/i.test(message);
 
     console.error("[verify-email] verification failed", {
       reason: isInvalid ? "invalid" : "unknown",


### PR DESCRIPTION
## Summary

- `/auth/verify-email` server action called the Payload REST SDK via `NEXT_PUBLIC_URL`, looping the request back through Next.js middleware. Envs where the public URL has no embedded basic-auth creds (local dev, anywhere middleware sees the request without an `Authorization` header) returned `401 - Authentication required` and the verification page showed the error state.
- Swapped the SDK call for the Payload Local API (`getPayload` + `payload.verifyEmail`). No HTTP roundtrip, no middleware, env-agnostic.
- Maps `Forbidden` (403, expired/used token) to `reason: "invalid"`; everything else stays `"unknown"`.

Regression introduced in #343 when verification moved out of the page render and into a server action.

## Test plan

- [ ] `BASIC_AUTH_ENABLED=true` locally, request a verification email, click the link → success state.
- [ ] Reuse the same token → "invalid" state (not "unknown").
- [ ] Staging smoke test on a fresh signup.