### PR TITLE
chore(client): add Google Search Console verification meta (AM-641)

### DIFF
--- a/client/src/app/(frontend)/[locale]/layout.tsx
+++ b/client/src/app/(frontend)/[locale]/layout.tsx
@@ -32,6 +32,9 @@ export async function generateMetadata({ params }: LayoutProps<"/[locale]">): Pr
   return {
     title: t("metadata-app-layout-title"),
     description: t("metadata-app-layout-description"),
+    verification: {
+      google: "4kLfup1Xp504REXNWUYnh6iRRYfWHzqILrIcgK00E9E",
+    },
     icons: {
       icon: [
         { url: "/favicon.ico", type: "image/x-icon" },


### PR DESCRIPTION
## Summary
- Adds `<meta name="google-site-verification" content="…" />` to root layout's `generateMetadata` — fulfills the GA team's [Search Console verification request](https://vizzuality.atlassian.net/browse/AM-641)
- Uses Next.js Metadata API `verification.google` field per [official docs](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#verification) — no env var (token is public, domain-bound, single GSC property)
- Closes [AM-641](https://vizzuality.atlassian.net/browse/AM-641)

## Test plan
- [ ] CI `Client Unit Tests` green
- [ ] After merge to `develop` and deploy, view-source on dev site → confirm `<meta name="google-site-verification" content="4kLfup1Xp504REXNWUYnh6iRRYfWHzqILrIcgK00E9E" />` present in `<head>`
- [ ] GA team confirms verification in Search Console

[AM-641]: https://vizzuality.atlassian.net/browse/AM-641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ