### PR TITLE
fix(client): location buffer — off-thread, flicker-free, reliable slider commit

### DIFF
--- a/client/src/components/map/sketch/index.tsx
+++ b/client/src/components/map/sketch/index.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef } from "react";
 
 import dynamic from "next/dynamic";
 
-import * as geodesicBufferOperator from "@arcgis/core/geometry/operators/geodesicBufferOperator";
+import * as geometryEngineAsync from "@arcgis/core/geometry/geometryEngineAsync";
 import Graphic from "@arcgis/core/Graphic";
 import GraphicsLayer from "@arcgis/core/layers/GraphicsLayer";
 import SketchViewModel from "@arcgis/core/widgets/Sketch/SketchViewModel";
@@ -25,10 +25,6 @@ import {
 import { useMap } from "@/components/map/provider";
 
 const Layer = dynamic(() => import("@/components/map/layers"), { ssr: false });
-
-if (!geodesicBufferOperator.isLoaded()) {
-  await geodesicBufferOperator.load();
-}
 
 export type SketchProps = {
   type?: "point" | "polygon" | "polyline";
@@ -64,12 +60,15 @@ export default function Sketch({
   const sketchViewModelRef = useRef<SketchViewModel | null>(null);
   const sketchViewModelOnCreateRef = useRef<IHandle | null>(null);
   const sketchViewModelOnUpdateRef = useRef<IHandle | null>(null);
+  const bufferDrawTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  // Monotonic token so a slow/stale async buffer can't overwrite a newer one.
+  const bufferDrawTokenRef = useRef(0);
 
   const drawBuffer = useCallback(
-    (l: __esri.Graphic) => {
+    async (l: __esri.Graphic) => {
       if (!l?.geometry) return;
 
-      bufferRef.current.removeAll();
+      const token = ++bufferDrawTokenRef.current;
 
       const buffer = new Graphic({
         symbol: BUFFER_SYMBOL,
@@ -80,13 +79,22 @@ export default function Sketch({
           location?.type !== "search"
             ? location?.buffer || BUFFERS[l.geometry.type]
             : BUFFERS[l.geometry.type];
-        const g = geodesicBufferOperator.execute(l.geometry, b, { unit: "kilometers" });
-
-        if (!g) return;
-
-        buffer.geometry = g;
+        // Async/off-thread: buffering a long polyline densifies into thousands of
+        // vertices and blocks the main thread when done synchronously.
+        try {
+          const g = await geometryEngineAsync.geodesicBuffer(l.geometry, b, "kilometers");
+          buffer.geometry = Array.isArray(g) ? g[0] : g;
+        } catch {
+          // Worker error/cancel: keep the current buffer instead of clearing it.
+          return;
+        }
       }
 
+      // A newer draw started while we awaited — let it win, don't clobber.
+      if (token !== bufferDrawTokenRef.current) return;
+
+      // Clear the previous buffer only once the new one is ready, to avoid flicker.
+      bufferRef.current.removeAll();
       if (buffer.geometry) {
         bufferRef.current.add(buffer);
       }
@@ -124,7 +132,15 @@ export default function Sketch({
       if (onUpdateChange) onUpdateChange(e);
 
       if (e.state === "active") {
-        drawBuffer(e.graphics[0].clone());
+        // Reshape fires "active" on every pointer move; debounce so we don't queue a
+        // buffer computation per move when dragging a long polyline.
+        const graphic = e.graphics[0].clone();
+        if (bufferDrawTimeoutRef.current) {
+          clearTimeout(bufferDrawTimeoutRef.current);
+        }
+        bufferDrawTimeoutRef.current = setTimeout(() => {
+          drawBuffer(graphic);
+        }, 150);
       }
 
       if (e.state === "complete" && e.graphics.length) {
@@ -219,15 +235,20 @@ export default function Sketch({
 
   useEffect(() => {
     layerRef.current.removeAll();
-    bufferRef.current.removeAll();
 
     if (LOCATION) {
       const L = LOCATION.clone();
-      if (!L.geometry) return;
-      L.symbol = SYMBOLS[L.geometry.type];
-      layerRef.current.add(L);
+      if (L.geometry) {
+        L.symbol = SYMBOLS[L.geometry.type];
+        layerRef.current.add(L);
 
-      drawBuffer(L);
+        // drawBuffer owns the buffer layer: it clears the old graphic only once the
+        // new (async) buffer is ready, so the buffer never blinks out mid-recompute.
+        drawBuffer(L);
+      }
+    } else {
+      // Nothing to draw — clear any leftover buffer.
+      bufferRef.current.removeAll();
     }
 
     handleListeners();
@@ -244,6 +265,14 @@ export default function Sketch({
       sketchViewModelRef.current?.update(layerRef.current.graphics.toArray());
     }
   }, [layerRef, enabled]);
+
+  useEffect(() => {
+    return () => {
+      if (bufferDrawTimeoutRef.current) {
+        clearTimeout(bufferDrawTimeoutRef.current);
+      }
+    };
+  }, []);
 
   return (
     <>

--- a/client/src/components/map/sketch/upload-dialog.tsx
+++ b/client/src/components/map/sketch/upload-dialog.tsx
@@ -70,7 +70,7 @@ export default function UploadDialog({ open, onOpenChange }: UploadDialogProps) 
             });
 
             if (esriGeometry) {
-              const bufferedGeometry = getGeometryWithBuffer(
+              const bufferedGeometry = await getGeometryWithBuffer(
                 esriGeometry,
                 BUFFERS[arcgisGeometry.type] || 0,
               );

--- a/client/src/containers/map/edit.tsx
+++ b/client/src/containers/map/edit.tsx
@@ -77,7 +77,7 @@ export default function MapEditContainer({
   }, [GEOMETRY, desktop]);
 
   const handleCreate = useCallback(
-    (graphic: __esri.Graphic) => {
+    async (graphic: __esri.Graphic) => {
       setSketch({ enabled: undefined, type: undefined });
 
       if (graphic.geometry) {
@@ -87,7 +87,7 @@ export default function MapEditContainer({
           buffer: BUFFERS[graphic.geometry.type],
         });
 
-        const g = getGeometryWithBuffer(graphic.geometry, BUFFERS[graphic.geometry.type]);
+        const g = await getGeometryWithBuffer(graphic.geometry, BUFFERS[graphic.geometry.type]);
         if (g?.extent) {
           setTmpBbox(g.extent);
         }
@@ -116,7 +116,7 @@ export default function MapEditContainer({
   }, [setSketch, setSketchAction]);
 
   const handleUpdate = useCallback(
-    (graphic: __esri.Graphic) => {
+    async (graphic: __esri.Graphic) => {
       if (!location || !graphic.geometry) return;
       const b = location.type !== "search" ? location.buffer : BUFFERS[graphic.geometry.type];
       // Update the location state with the updated geometry
@@ -127,7 +127,7 @@ export default function MapEditContainer({
       });
 
       // Optionally update the bounding box based on the updated geometry
-      const g = getGeometryWithBuffer(graphic.geometry, b);
+      const g = await getGeometryWithBuffer(graphic.geometry, b);
       if (g?.extent) {
         setTmpBbox(g.extent);
       }

--- a/client/src/containers/map/edit.tsx
+++ b/client/src/containers/map/edit.tsx
@@ -1,26 +1,17 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useMemo } from "react";
 
 import dynamic from "next/dynamic";
 
-import { useAtom, useSetAtom } from "jotai";
+import { useAtomValue } from "jotai";
 
-import { getGeometryWithBuffer, useLocationGeometry } from "@/lib/location";
+import { useLocationGeometry } from "@/lib/location";
 
-import {
-  gridHoverAtom,
-  sketchActionAtom,
-  sketchAtom,
-  tmpBboxAtom,
-  useFormLocation,
-  useSyncGridSelectedDataset,
-  useSyncLocation,
-} from "@/app/(frontend)/store";
-
-import { BUFFERS } from "@/constants/map";
+import { tmpBboxAtom, useFormLocation, useSyncGridSelectedDataset } from "@/app/(frontend)/store";
 
 import GridLegend from "@/containers/map/grid-legend/grid";
+import { useSketchHandlers } from "@/containers/map/use-sketch-handlers";
 
 import Controls from "@/components/map/controls";
 import BasemapControl from "@/components/map/controls/basemap";
@@ -48,18 +39,24 @@ export default function MapEditContainer({
   desktop?: boolean;
   gridEnabled?: boolean;
 }) {
-  const [tmpBbox, setTmpBbox] = useAtom(tmpBboxAtom);
+  const tmpBbox = useAtomValue(tmpBboxAtom);
 
   const { location: defaultLocation } = useFormLocation();
   const GEOMETRY = useLocationGeometry(defaultLocation);
 
-  const [sketch, setSketch] = useAtom(sketchAtom);
-  const [sketchAction, setSketchAction] = useAtom(sketchActionAtom);
-  const sketchActionTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  const setGridHover = useSetAtom(gridHoverAtom);
-  const [location, setLocation] = useSyncLocation();
   const [gridSelectedDataset] = useSyncGridSelectedDataset();
+
+  const {
+    sketch,
+    sketchAction,
+    location,
+    handleCreate,
+    handleCreateChange,
+    handleCancel,
+    handleUpdate,
+    handleUpdateChange,
+    handlePointerLeave,
+  } = useSketchHandlers();
 
   const defaultBbox = useMemo(() => {
     if (GEOMETRY?.extent)
@@ -75,108 +72,6 @@ export default function MapEditContainer({
 
     return [-8999366.738755312, -4376503.729887867, -4792272.701940329, 2354846.7290161047];
   }, [GEOMETRY, desktop]);
-
-  const handleCreate = useCallback(
-    async (graphic: __esri.Graphic) => {
-      setSketch({ enabled: undefined, type: undefined });
-
-      if (graphic.geometry) {
-        setLocation({
-          type: graphic.geometry.type,
-          geometry: graphic.geometry.toJSON(),
-          buffer: BUFFERS[graphic.geometry.type],
-        });
-
-        const g = await getGeometryWithBuffer(graphic.geometry, BUFFERS[graphic.geometry.type]);
-        if (g?.extent) {
-          setTmpBbox(g.extent);
-        }
-      }
-
-      sketchActionTimeoutRef.current = setTimeout(() => {
-        setSketchAction({ type: undefined, state: undefined, geometryType: undefined });
-      }, 5000);
-    },
-    [setTmpBbox, setSketch, setLocation, setSketchAction],
-  );
-
-  const handleCreateChange = useCallback(
-    (e: __esri.SketchViewModelCreateEvent) => {
-      if (sketchActionTimeoutRef.current) {
-        clearTimeout(sketchActionTimeoutRef.current);
-      }
-      setSketchAction({ type: "create", state: e.state, geometryType: sketch.type });
-    },
-    [setSketchAction, sketch.type],
-  );
-
-  const handleCancel = useCallback(() => {
-    setSketch({ enabled: undefined, type: undefined });
-    setSketchAction({ type: undefined, state: undefined, geometryType: undefined });
-  }, [setSketch, setSketchAction]);
-
-  const handleUpdate = useCallback(
-    async (graphic: __esri.Graphic) => {
-      if (!location || !graphic.geometry) return;
-      const b = location.type !== "search" ? location.buffer : BUFFERS[graphic.geometry.type];
-      // Update the location state with the updated geometry
-      setLocation({
-        type: graphic.geometry.type,
-        geometry: graphic.geometry.toJSON(),
-        buffer: b,
-      });
-
-      // Optionally update the bounding box based on the updated geometry
-      const g = await getGeometryWithBuffer(graphic.geometry, b);
-      if (g?.extent) {
-        setTmpBbox(g.extent);
-      }
-
-      setSketch({ enabled: undefined, type: undefined });
-      setSketchAction({ type: undefined, state: undefined, geometryType: undefined });
-    },
-    [location, setLocation, setTmpBbox, setSketch, setSketchAction],
-  );
-
-  const handleUpdateChange = useCallback(
-    (e: __esri.SketchViewModelUpdateEvent) => {
-      if (sketchActionTimeoutRef.current) {
-        clearTimeout(sketchActionTimeoutRef.current);
-      }
-
-      if (!!e.graphics.length && e.graphics[0].geometry) {
-        setSketchAction({
-          type: "update",
-          state: e.state,
-          geometryType: e.graphics[0].geometry.type,
-        });
-      }
-    },
-    [setSketchAction],
-  );
-
-  const handlePointerLeave = useCallback(() => {
-    setGridHover({
-      id: null,
-      cell: undefined,
-      index: undefined,
-      values: [],
-      x: null,
-      y: null,
-      coordinates: undefined,
-    });
-  }, [setGridHover]);
-
-  useEffect(() => {
-    if (sketch.enabled === "edit") {
-      // focus map
-      const mapElement = document.querySelector("#map-default .esri-view-surface") as HTMLElement;
-
-      if (mapElement) {
-        mapElement.focus();
-      }
-    }
-  }, [sketch.enabled]);
 
   return (
     <div className="relative flex w-full grow flex-col">

--- a/client/src/containers/map/index.tsx
+++ b/client/src/containers/map/index.tsx
@@ -1,28 +1,18 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useMemo } from "react";
 
 import dynamic from "next/dynamic";
 
-import { useAtom, useSetAtom } from "jotai";
+import { useAtomValue } from "jotai";
 
 import { useDebounce } from "@/lib/hooks";
-import { getGeometryWithBuffer } from "@/lib/location";
 
-import {
-  gridHoverAtom,
-  sketchActionAtom,
-  sketchAtom,
-  tmpBboxAtom,
-  useSyncBbox,
-  useSyncGridSelectedDataset,
-  useSyncLocation,
-} from "@/app/(frontend)/store";
-
-import { BUFFERS } from "@/constants/map";
+import { tmpBboxAtom, useSyncBbox, useSyncGridSelectedDataset } from "@/app/(frontend)/store";
 
 import GridLegend from "@/containers/map/grid-legend/grid";
 import { SketchTooltips } from "@/containers/map/sketch-tooltips";
+import { useSketchHandlers } from "@/containers/map/use-sketch-handlers";
 
 import Controls from "@/components/map/controls";
 import BasemapControl from "@/components/map/controls/basemap";
@@ -51,15 +41,21 @@ export default function MapContainer({
   gridEnabled?: boolean;
 }) {
   const [bbox, setBbox] = useSyncBbox();
-  const [tmpBbox, setTmpBbox] = useAtom(tmpBboxAtom);
+  const tmpBbox = useAtomValue(tmpBboxAtom);
 
-  const [sketch, setSketch] = useAtom(sketchAtom);
-  const [sketchAction, setSketchAction] = useAtom(sketchActionAtom);
-  const sketchActionTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  const setGridHover = useSetAtom(gridHoverAtom);
-  const [location, setLocation] = useSyncLocation();
   const [gridSelectedDataset] = useSyncGridSelectedDataset();
+
+  const {
+    sketch,
+    sketchAction,
+    location,
+    handleCreate,
+    handleCreateChange,
+    handleCancel,
+    handleUpdate,
+    handleUpdateChange,
+    handlePointerLeave,
+  } = useSketchHandlers();
 
   const defaultBbox = useMemo(() => {
     if (bbox) return bbox;
@@ -73,106 +69,6 @@ export default function MapContainer({
   const handleMapMove = useDebounce((extent: __esri.Extent) => {
     setBbox([extent.xmin, extent.ymin, extent.xmax, extent.ymax]);
   }, 500);
-
-  const handleCreate = useCallback(
-    async (graphic: __esri.Graphic) => {
-      setSketch({ enabled: undefined, type: undefined });
-
-      if (!graphic.geometry) return;
-      setLocation({
-        type: graphic.geometry.type,
-        geometry: graphic.geometry.toJSON(),
-        buffer: BUFFERS[graphic.geometry.type],
-      });
-
-      const g = await getGeometryWithBuffer(graphic.geometry, BUFFERS[graphic.geometry.type]);
-      if (g?.extent) {
-        setTmpBbox(g.extent);
-      }
-
-      sketchActionTimeoutRef.current = setTimeout(() => {
-        setSketchAction({ type: undefined, state: undefined, geometryType: undefined });
-      }, 5000);
-    },
-    [setTmpBbox, setSketch, setLocation, setSketchAction],
-  );
-
-  const handleCreateChange = useCallback(
-    (e: __esri.SketchViewModelCreateEvent) => {
-      if (sketchActionTimeoutRef.current) {
-        clearTimeout(sketchActionTimeoutRef.current);
-      }
-      setSketchAction({ type: "create", state: e.state, geometryType: sketch.type });
-    },
-    [setSketchAction, sketch.type],
-  );
-
-  const handleCancel = useCallback(() => {
-    setSketch({ enabled: undefined, type: undefined });
-    setSketchAction({ type: undefined, state: undefined, geometryType: undefined });
-  }, [setSketch, setSketchAction]);
-
-  const handleUpdate = useCallback(
-    async (graphic: __esri.Graphic) => {
-      if (!location || !graphic.geometry) return;
-      const b = location.type !== "search" ? location.buffer : BUFFERS[graphic.geometry.type];
-      // Update the location state with the updated geometry
-      setLocation({
-        type: graphic.geometry.type,
-        geometry: graphic.geometry.toJSON(),
-        buffer: b,
-      });
-
-      // Optionally update the bounding box based on the updated geometry
-      const g = await getGeometryWithBuffer(graphic.geometry, b);
-      if (g?.extent) {
-        setTmpBbox(g.extent);
-      }
-
-      setSketch({ enabled: undefined, type: undefined });
-      setSketchAction({ type: undefined, state: undefined, geometryType: undefined });
-    },
-    [location, setLocation, setTmpBbox, setSketch, setSketchAction],
-  );
-
-  const handleUpdateChange = useCallback(
-    (e: __esri.SketchViewModelUpdateEvent) => {
-      if (sketchActionTimeoutRef.current) {
-        clearTimeout(sketchActionTimeoutRef.current);
-      }
-      if (!!e.graphics.length && e.graphics[0].geometry) {
-        setSketchAction({
-          type: "update",
-          state: e.state,
-          geometryType: e.graphics[0].geometry.type,
-        });
-      }
-    },
-    [setSketchAction],
-  );
-
-  const handlePointerLeave = useCallback(() => {
-    setGridHover({
-      id: null,
-      cell: undefined,
-      index: undefined,
-      values: [],
-      x: null,
-      y: null,
-      coordinates: undefined,
-    });
-  }, [setGridHover]);
-
-  useEffect(() => {
-    if (sketch.enabled === "edit") {
-      // focus map
-      const mapElement = document.querySelector("#map-default .esri-view-surface") as HTMLElement;
-
-      if (mapElement) {
-        mapElement.focus();
-      }
-    }
-  }, [sketch.enabled]);
 
   return (
     <div className="relative flex w-full grow flex-col">

--- a/client/src/containers/map/index.tsx
+++ b/client/src/containers/map/index.tsx
@@ -75,7 +75,7 @@ export default function MapContainer({
   }, 500);
 
   const handleCreate = useCallback(
-    (graphic: __esri.Graphic) => {
+    async (graphic: __esri.Graphic) => {
       setSketch({ enabled: undefined, type: undefined });
 
       if (!graphic.geometry) return;
@@ -85,7 +85,7 @@ export default function MapContainer({
         buffer: BUFFERS[graphic.geometry.type],
       });
 
-      const g = getGeometryWithBuffer(graphic.geometry, BUFFERS[graphic.geometry.type]);
+      const g = await getGeometryWithBuffer(graphic.geometry, BUFFERS[graphic.geometry.type]);
       if (g?.extent) {
         setTmpBbox(g.extent);
       }
@@ -113,7 +113,7 @@ export default function MapContainer({
   }, [setSketch, setSketchAction]);
 
   const handleUpdate = useCallback(
-    (graphic: __esri.Graphic) => {
+    async (graphic: __esri.Graphic) => {
       if (!location || !graphic.geometry) return;
       const b = location.type !== "search" ? location.buffer : BUFFERS[graphic.geometry.type];
       // Update the location state with the updated geometry
@@ -124,7 +124,7 @@ export default function MapContainer({
       });
 
       // Optionally update the bounding box based on the updated geometry
-      const g = getGeometryWithBuffer(graphic.geometry, b);
+      const g = await getGeometryWithBuffer(graphic.geometry, b);
       if (g?.extent) {
         setTmpBbox(g.extent);
       }

--- a/client/src/containers/map/layer-manager/grid-layer.tsx
+++ b/client/src/containers/map/layer-manager/grid-layer.tsx
@@ -536,7 +536,7 @@ export default function GridLayer() {
     setAlert(info);
   }, []);
 
-  const handleConfirmAlert = useCallback(() => {
+  const handleConfirmAlert = useCallback(async () => {
     if (!alert?.coordinate) return;
 
     const cell = latLngToCell(alert.coordinate[1], alert.coordinate[0], 6);
@@ -557,7 +557,7 @@ export default function GridLayer() {
       buffer: BUFFERS.point,
     });
 
-    const gWithBuffer = getGeometryWithBuffer(g, BUFFERS.point);
+    const gWithBuffer = await getGeometryWithBuffer(g, BUFFERS.point);
     if (gWithBuffer?.extent) {
       setTmpBbox(gWithBuffer.extent);
     }

--- a/client/src/containers/map/use-sketch-handlers.ts
+++ b/client/src/containers/map/use-sketch-handlers.ts
@@ -1,0 +1,147 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+import { useAtom, useSetAtom } from "jotai";
+
+import { getGeometryWithBuffer } from "@/lib/location";
+
+import {
+  gridHoverAtom,
+  sketchActionAtom,
+  sketchAtom,
+  tmpBboxAtom,
+  useSyncLocation,
+} from "@/app/(frontend)/store";
+
+import { BUFFERS } from "@/constants/map";
+
+// Sketch/draw flow shared by the map containers (view + edit): create/update/cancel,
+// the grid-hover reset, and the edit-focus effect. Extracted so both containers wire
+// the same <Sketch> without duplicating the whole handler block.
+export function useSketchHandlers() {
+  const setTmpBbox = useSetAtom(tmpBboxAtom);
+
+  const [sketch, setSketch] = useAtom(sketchAtom);
+  const [sketchAction, setSketchAction] = useAtom(sketchActionAtom);
+  const sketchActionTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const setGridHover = useSetAtom(gridHoverAtom);
+  const [location, setLocation] = useSyncLocation();
+
+  const handleCreate = useCallback(
+    async (graphic: __esri.Graphic) => {
+      setSketch({ enabled: undefined, type: undefined });
+
+      if (graphic.geometry) {
+        setLocation({
+          type: graphic.geometry.type,
+          geometry: graphic.geometry.toJSON(),
+          buffer: BUFFERS[graphic.geometry.type],
+        });
+
+        const g = await getGeometryWithBuffer(graphic.geometry, BUFFERS[graphic.geometry.type]);
+        if (g?.extent) {
+          setTmpBbox(g.extent);
+        }
+      }
+
+      sketchActionTimeoutRef.current = setTimeout(() => {
+        setSketchAction({ type: undefined, state: undefined, geometryType: undefined });
+      }, 5000);
+    },
+    [setTmpBbox, setSketch, setLocation, setSketchAction],
+  );
+
+  const handleCreateChange = useCallback(
+    (e: __esri.SketchViewModelCreateEvent) => {
+      if (sketchActionTimeoutRef.current) {
+        clearTimeout(sketchActionTimeoutRef.current);
+      }
+      setSketchAction({ type: "create", state: e.state, geometryType: sketch.type });
+    },
+    [setSketchAction, sketch.type],
+  );
+
+  const handleCancel = useCallback(() => {
+    setSketch({ enabled: undefined, type: undefined });
+    setSketchAction({ type: undefined, state: undefined, geometryType: undefined });
+  }, [setSketch, setSketchAction]);
+
+  const handleUpdate = useCallback(
+    async (graphic: __esri.Graphic) => {
+      if (!location || !graphic.geometry) return;
+      const b = location.type !== "search" ? location.buffer : BUFFERS[graphic.geometry.type];
+      // Update the location state with the updated geometry
+      setLocation({
+        type: graphic.geometry.type,
+        geometry: graphic.geometry.toJSON(),
+        buffer: b,
+      });
+
+      // Optionally update the bounding box based on the updated geometry
+      const g = await getGeometryWithBuffer(graphic.geometry, b);
+      if (g?.extent) {
+        setTmpBbox(g.extent);
+      }
+
+      setSketch({ enabled: undefined, type: undefined });
+      setSketchAction({ type: undefined, state: undefined, geometryType: undefined });
+    },
+    [location, setLocation, setTmpBbox, setSketch, setSketchAction],
+  );
+
+  const handleUpdateChange = useCallback(
+    (e: __esri.SketchViewModelUpdateEvent) => {
+      if (sketchActionTimeoutRef.current) {
+        clearTimeout(sketchActionTimeoutRef.current);
+      }
+      if (!!e.graphics.length && e.graphics[0].geometry) {
+        setSketchAction({
+          type: "update",
+          state: e.state,
+          geometryType: e.graphics[0].geometry.type,
+        });
+      }
+    },
+    [setSketchAction],
+  );
+
+  const handlePointerLeave = useCallback(() => {
+    setGridHover({
+      id: null,
+      cell: undefined,
+      index: undefined,
+      values: [],
+      x: null,
+      y: null,
+      coordinates: undefined,
+    });
+  }, [setGridHover]);
+
+  useEffect(() => {
+    if (sketch.enabled === "edit") {
+      // focus map
+      const mapElement = document.querySelector("#map-default .esri-view-surface") as HTMLElement;
+
+      if (mapElement) {
+        mapElement.focus();
+      }
+    }
+  }, [sketch.enabled]);
+
+  return {
+    sketch,
+    setSketch,
+    sketchAction,
+    setSketchAction,
+    location,
+    setLocation,
+    handleCreate,
+    handleCreateChange,
+    handleCancel,
+    handleUpdate,
+    handleUpdateChange,
+    handlePointerLeave,
+  };
+}

--- a/client/src/containers/report/grid/table/item.tsx
+++ b/client/src/containers/report/grid/table/item.tsx
@@ -90,7 +90,7 @@ export const GridTableItem = (
     });
   }, [gridDatasets, queryMeta.data, rest]);
 
-  const handleClick = () => {
+  const handleClick = async () => {
     const latLng = cellToLatLng(cell);
 
     const p = new Point({ x: latLng[1], y: latLng[0], spatialReference: { wkid: 4326 } });
@@ -100,7 +100,7 @@ export const GridTableItem = (
 
     setLocation({ type: "point", geometry: g.toJSON(), buffer: BUFFERS.point });
 
-    const gWithBuffer = getGeometryWithBuffer(g, BUFFERS.point);
+    const gWithBuffer = await getGeometryWithBuffer(g, BUFFERS.point);
     if (gWithBuffer?.extent) {
       setTmpBbox(gWithBuffer.extent);
     }

--- a/client/src/containers/report/location/buffer/slider.tsx
+++ b/client/src/containers/report/location/buffer/slider.tsx
@@ -10,12 +10,12 @@ export function BufferSlider({
   isCalculating,
   onValueChange,
   onValueCommit,
-}: {
+}: Readonly<{
   bufferValue: number;
   isCalculating: boolean;
   onValueChange: (value: number[]) => void;
   onValueCommit: () => void;
-}) {
+}>) {
   const t = useTranslations();
 
   return (

--- a/client/src/containers/report/location/buffer/slider.tsx
+++ b/client/src/containers/report/location/buffer/slider.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { Slider } from "@/components/ui/slider";
+import { Spinner } from "@/components/ui/spinner";
+
+export function BufferSlider({
+  bufferValue,
+  isCalculating,
+  onValueChange,
+  onValueCommit,
+}: {
+  bufferValue: number;
+  isCalculating: boolean;
+  onValueChange: (value: number[]) => void;
+  onValueCommit: () => void;
+}) {
+  const t = useTranslations();
+
+  return (
+    <section className="space-y-2">
+      <div className="flex items-end justify-between">
+        <div className="text-sm leading-none font-semibold text-blue-500">
+          {t("grid-sidebar-report-location-buffer-size")}
+        </div>
+        <div className="text-foreground flex items-center gap-1 text-xs leading-none">
+          {isCalculating && <Spinner className="text-muted-foreground size-3" />}
+          {`${bufferValue} km`}
+        </div>
+      </div>
+      <div className="space-y-1 px-1">
+        <Slider
+          min={1}
+          max={100}
+          step={1}
+          value={[bufferValue]}
+          minStepsBetweenThumbs={1}
+          onValueChange={onValueChange}
+          onValueCommit={onValueCommit}
+        />
+
+        <div className="text-2xs text-muted-foreground flex w-full justify-between font-bold">
+          <span>1 km</span>
+          <span>100 km</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/containers/report/location/buffer/use-location-buffer.ts
+++ b/client/src/containers/report/location/buffer/use-location-buffer.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import * as geodesicAreaOperator from "@arcgis/core/geometry/operators/geodeticAreaOperator";
+import { useSetAtom } from "jotai";
+
+import {
+  getGeometryWithBuffer,
+  useLocation,
+  useLocationGeometryWithStatus,
+  useLocationTitle,
+} from "@/lib/location";
+
+import { tmpBboxAtom, useSyncLocation } from "@/app/(frontend)/store";
+
+import { BUFFERS } from "@/constants/map";
+
+if (!geodesicAreaOperator.isLoaded()) {
+  await geodesicAreaOperator.load();
+}
+
+// Buffer-slider state shared by the report location "create" and "confirm" panels.
+// The slider/label are driven from local state and committed to the (shared) location
+// once per drag instead of once per pointer-move tick, so the off-thread buffer isn't
+// recomputed on every tick.
+export function useLocationBuffer() {
+  const setTmpBbox = useSetAtom(tmpBboxAtom);
+
+  const [location, setLocation] = useSyncLocation();
+  const TITLE = useLocationTitle(location);
+  const LOCATION = useLocation(location);
+  const { geometry: GEOMETRY, isCalculating } = useLocationGeometryWithStatus(location);
+
+  const AREA = useMemo(() => {
+    if (!GEOMETRY) return 0;
+    return geodesicAreaOperator.execute(GEOMETRY, { unit: "square-kilometers" });
+  }, [GEOMETRY]);
+
+  const committedBuffer =
+    (location && location.type !== "search" ? location.buffer : undefined) ||
+    BUFFERS[LOCATION?.geometry?.type || "point"];
+  const [bufferValue, setBufferValue] = useState(committedBuffer);
+
+  // Latest dragged value, captured synchronously so the commit never reads a stale
+  // React-state value. Radix only fires onValueCommit when its (controlled) value
+  // differs from the slide-start value; on a fast drag the controlled value hasn't
+  // flushed by pointer-up, so onValueCommit gets skipped and the buffer never updates.
+  // A trailing debounce off onValueChange guarantees the final value commits.
+  const pendingBufferRef = useRef(committedBuffer);
+  const commitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Sync local slider state when the committed buffer changes from outside (reset,
+  // upload, edit-location).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setBufferValue(committedBuffer);
+    pendingBufferRef.current = committedBuffer;
+  }, [committedBuffer]);
+
+  useEffect(() => {
+    return () => {
+      if (commitTimeoutRef.current) clearTimeout(commitTimeoutRef.current);
+    };
+  }, []);
+
+  const commitBuffer = async () => {
+    const value = pendingBufferRef.current;
+    setLocation((prev) => (prev ? { ...prev, buffer: value } : prev));
+
+    const geometry = LOCATION?.geometry;
+    if (!location || !geometry || (location.type !== "point" && location.type !== "polyline")) {
+      return;
+    }
+
+    const gWithBuffer = await getGeometryWithBuffer(geometry, value);
+    if (gWithBuffer?.extent) {
+      setTmpBbox(gWithBuffer.extent);
+    }
+  };
+
+  const onValueChange = (value: number[]) => {
+    pendingBufferRef.current = value[0];
+    setBufferValue(value[0]);
+    if (commitTimeoutRef.current) clearTimeout(commitTimeoutRef.current);
+    commitTimeoutRef.current = setTimeout(commitBuffer, 120);
+  };
+
+  // Radix fires this on release for slow drags / track clicks. Commit immediately and
+  // cancel the pending debounce; reads pendingBufferRef (not the possibly-stale arg).
+  const onValueCommit = () => {
+    if (commitTimeoutRef.current) clearTimeout(commitTimeoutRef.current);
+    commitBuffer();
+  };
+
+  return {
+    location,
+    setLocation,
+    LOCATION,
+    TITLE,
+    AREA,
+    isCalculating,
+    bufferValue,
+    onValueChange,
+    onValueCommit,
+  };
+}

--- a/client/src/containers/report/location/confirm/index.tsx
+++ b/client/src/containers/report/location/confirm/index.tsx
@@ -1,105 +1,35 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
-
 import ReactMarkdown from "react-markdown";
 
-import * as geodesicAreaOperator from "@arcgis/core/geometry/operators/geodeticAreaOperator";
 import { useSetAtom } from "jotai";
 import { useTranslations } from "next-intl";
 
 import { formatNumber } from "@/lib/formats";
-import {
-  getGeometryWithBuffer,
-  useLocation,
-  useLocationGeometryWithStatus,
-  useLocationTitle,
-} from "@/lib/location";
 
-import { sketchActionAtom, tmpBboxAtom, useSyncLocation } from "@/app/(frontend)/store";
+import { sketchActionAtom } from "@/app/(frontend)/store";
 
-import { BUFFERS } from "@/constants/map";
+import { BufferSlider } from "@/containers/report/location/buffer/slider";
+import { useLocationBuffer } from "@/containers/report/location/buffer/use-location-buffer";
 
 import { Button } from "@/components/ui/button";
-import { Slider } from "@/components/ui/slider";
 import { Spinner } from "@/components/ui/spinner";
-
-if (!geodesicAreaOperator.isLoaded()) {
-  await geodesicAreaOperator.load();
-}
 
 export default function Confirm({ onConfirm }: { onConfirm: () => void }) {
   const t = useTranslations();
   const setSketchAction = useSetAtom(sketchActionAtom);
-  const setTmpBbox = useSetAtom(tmpBboxAtom);
 
-  const [location, setLocation] = useSyncLocation();
-  const TITLE = useLocationTitle(location);
-  const LOCATION = useLocation(location);
-  const { geometry: GEOMETRY, isCalculating } = useLocationGeometryWithStatus(location);
-
-  const AREA = useMemo(() => {
-    if (!GEOMETRY) return 0;
-    return geodesicAreaOperator.execute(GEOMETRY, { unit: "square-kilometers" });
-  }, [GEOMETRY]);
-
-  // Local buffer value drives the slider/label live while dragging. We commit it to
-  // the (shared) location state once per drag instead of once per pointer-move tick.
-  const committedBuffer =
-    (location && location.type !== "search" ? location.buffer : undefined) ||
-    BUFFERS[LOCATION?.geometry?.type || "point"];
-  const [bufferValue, setBufferValue] = useState(committedBuffer);
-
-  // Latest dragged value, captured synchronously so the commit never reads a stale
-  // React-state value. Radix only fires onValueCommit when its (controlled) value
-  // differs from the slide-start value; on a fast drag the controlled value hasn't
-  // flushed by pointer-up, so onValueCommit gets skipped and the buffer never updates.
-  // A trailing debounce off onValueChange guarantees the final value commits.
-  const pendingBufferRef = useRef(committedBuffer);
-  const commitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Sync local slider state when the committed buffer changes from outside (reset,
-  // upload, edit-location).
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setBufferValue(committedBuffer);
-    pendingBufferRef.current = committedBuffer;
-  }, [committedBuffer]);
-
-  useEffect(() => {
-    return () => {
-      if (commitTimeoutRef.current) clearTimeout(commitTimeoutRef.current);
-    };
-  }, []);
-
-  const commitBuffer = async () => {
-    const value = pendingBufferRef.current;
-    setLocation((prev) => (prev ? { ...prev, buffer: value } : prev));
-
-    const geometry = LOCATION?.geometry;
-    if (!location || !geometry || (location.type !== "point" && location.type !== "polyline")) {
-      return;
-    }
-
-    const gWithBuffer = await getGeometryWithBuffer(geometry, value);
-    if (gWithBuffer?.extent) {
-      setTmpBbox(gWithBuffer.extent);
-    }
-  };
-
-  const onValueChange = (value: number[]) => {
-    pendingBufferRef.current = value[0];
-    setBufferValue(value[0]);
-    if (commitTimeoutRef.current) clearTimeout(commitTimeoutRef.current);
-    commitTimeoutRef.current = setTimeout(commitBuffer, 120);
-  };
-
-  // Radix fires this on release for slow drags / track clicks. Commit immediately and
-  // cancel the pending debounce; reads pendingBufferRef (not the possibly-stale arg).
-  const onValueCommit = () => {
-    if (commitTimeoutRef.current) clearTimeout(commitTimeoutRef.current);
-    commitBuffer();
-  };
+  const {
+    location,
+    setLocation,
+    LOCATION,
+    TITLE,
+    AREA,
+    isCalculating,
+    bufferValue,
+    onValueChange,
+    onValueCommit,
+  } = useLocationBuffer();
 
   if (!location || !LOCATION) return null;
 
@@ -143,33 +73,12 @@ export default function Confirm({ onConfirm }: { onConfirm: () => void }) {
       </section>
 
       {location.type !== "search" && LOCATION?.geometry?.type !== "polygon" && (
-        <section className="space-y-2">
-          <div className="flex items-end justify-between">
-            <div className="text-sm leading-none font-semibold text-blue-500">
-              {t("grid-sidebar-report-location-buffer-size")}
-            </div>
-            <div className="text-foreground flex items-center gap-1 text-xs leading-none">
-              {isCalculating && <Spinner className="text-muted-foreground size-3" />}
-              {`${bufferValue} km`}
-            </div>
-          </div>
-          <div className="space-y-1 px-1">
-            <Slider
-              min={1}
-              max={100}
-              step={1}
-              value={[bufferValue]}
-              minStepsBetweenThumbs={1}
-              onValueChange={onValueChange}
-              onValueCommit={onValueCommit}
-            />
-
-            <div className="text-2xs text-muted-foreground flex w-full justify-between font-bold">
-              <span>1 km</span>
-              <span>100 km</span>
-            </div>
-          </div>
-        </section>
+        <BufferSlider
+          bufferValue={bufferValue}
+          isCalculating={isCalculating}
+          onValueChange={onValueChange}
+          onValueCommit={onValueCommit}
+        />
       )}
     </div>
   );

--- a/client/src/containers/report/location/confirm/index.tsx
+++ b/client/src/containers/report/location/confirm/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import ReactMarkdown from "react-markdown";
 
@@ -9,11 +9,10 @@ import { useSetAtom } from "jotai";
 import { useTranslations } from "next-intl";
 
 import { formatNumber } from "@/lib/formats";
-import { useDebounce } from "@/lib/hooks";
 import {
   getGeometryWithBuffer,
   useLocation,
-  useLocationGeometry,
+  useLocationGeometryWithStatus,
   useLocationTitle,
 } from "@/lib/location";
 
@@ -23,6 +22,7 @@ import { BUFFERS } from "@/constants/map";
 
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
+import { Spinner } from "@/components/ui/spinner";
 
 if (!geodesicAreaOperator.isLoaded()) {
   await geodesicAreaOperator.load();
@@ -36,34 +36,69 @@ export default function Confirm({ onConfirm }: { onConfirm: () => void }) {
   const [location, setLocation] = useSyncLocation();
   const TITLE = useLocationTitle(location);
   const LOCATION = useLocation(location);
-  const GEOMETRY = useLocationGeometry(location);
-
-  const onValueChangeDebounced = useDebounce(() => {
-    if (!location || (location.type !== "point" && location.type !== "polyline")) return;
-    const gWithBuffer = getGeometryWithBuffer(GEOMETRY, location.buffer);
-
-    if (gWithBuffer?.extent) {
-      setTmpBbox(gWithBuffer.extent);
-    }
-  }, 500);
+  const { geometry: GEOMETRY, isCalculating } = useLocationGeometryWithStatus(location);
 
   const AREA = useMemo(() => {
     if (!GEOMETRY) return 0;
     return geodesicAreaOperator.execute(GEOMETRY, { unit: "square-kilometers" });
   }, [GEOMETRY]);
 
-  const onValueChange = (value: number[]) => {
-    setLocation((prev) => {
-      if (prev) {
-        return {
-          ...prev,
-          buffer: value[0],
-        };
-      }
-      return prev;
-    });
+  // Local buffer value drives the slider/label live while dragging. We commit it to
+  // the (shared) location state once per drag instead of once per pointer-move tick.
+  const committedBuffer =
+    (location && location.type !== "search" ? location.buffer : undefined) ||
+    BUFFERS[LOCATION?.geometry?.type || "point"];
+  const [bufferValue, setBufferValue] = useState(committedBuffer);
 
-    onValueChangeDebounced();
+  // Latest dragged value, captured synchronously so the commit never reads a stale
+  // React-state value. Radix only fires onValueCommit when its (controlled) value
+  // differs from the slide-start value; on a fast drag the controlled value hasn't
+  // flushed by pointer-up, so onValueCommit gets skipped and the buffer never updates.
+  // A trailing debounce off onValueChange guarantees the final value commits.
+  const pendingBufferRef = useRef(committedBuffer);
+  const commitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Sync local slider state when the committed buffer changes from outside (reset,
+  // upload, edit-location).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setBufferValue(committedBuffer);
+    pendingBufferRef.current = committedBuffer;
+  }, [committedBuffer]);
+
+  useEffect(() => {
+    return () => {
+      if (commitTimeoutRef.current) clearTimeout(commitTimeoutRef.current);
+    };
+  }, []);
+
+  const commitBuffer = async () => {
+    const value = pendingBufferRef.current;
+    setLocation((prev) => (prev ? { ...prev, buffer: value } : prev));
+
+    const geometry = LOCATION?.geometry;
+    if (!location || !geometry || (location.type !== "point" && location.type !== "polyline")) {
+      return;
+    }
+
+    const gWithBuffer = await getGeometryWithBuffer(geometry, value);
+    if (gWithBuffer?.extent) {
+      setTmpBbox(gWithBuffer.extent);
+    }
+  };
+
+  const onValueChange = (value: number[]) => {
+    pendingBufferRef.current = value[0];
+    setBufferValue(value[0]);
+    if (commitTimeoutRef.current) clearTimeout(commitTimeoutRef.current);
+    commitTimeoutRef.current = setTimeout(commitBuffer, 120);
+  };
+
+  // Radix fires this on release for slow drags / track clicks. Commit immediately and
+  // cancel the pending debounce; reads pendingBufferRef (not the possibly-stale arg).
+  const onValueCommit = () => {
+    if (commitTimeoutRef.current) clearTimeout(commitTimeoutRef.current);
+    commitBuffer();
   };
 
   if (!location || !LOCATION) return null;
@@ -75,7 +110,8 @@ export default function Confirm({ onConfirm }: { onConfirm: () => void }) {
           <div className="text-muted-foreground text-sm leading-none font-semibold uppercase">
             {TITLE}
           </div>
-          <div className="text-foreground text-xs leading-none font-bold">
+          <div className="text-foreground flex items-center gap-1 text-xs leading-none font-bold">
+            {isCalculating && <Spinner className="text-muted-foreground size-3" />}
             {formatNumber(AREA, {
               maximumFractionDigits: 0,
             })}{" "}
@@ -112,8 +148,9 @@ export default function Confirm({ onConfirm }: { onConfirm: () => void }) {
             <div className="text-sm leading-none font-semibold text-blue-500">
               {t("grid-sidebar-report-location-buffer-size")}
             </div>
-            <div className="text-foreground text-xs leading-none">
-              {`${location.buffer || BUFFERS[LOCATION?.geometry?.type || "point"]} km`}
+            <div className="text-foreground flex items-center gap-1 text-xs leading-none">
+              {isCalculating && <Spinner className="text-muted-foreground size-3" />}
+              {`${bufferValue} km`}
             </div>
           </div>
           <div className="space-y-1 px-1">
@@ -121,9 +158,10 @@ export default function Confirm({ onConfirm }: { onConfirm: () => void }) {
               min={1}
               max={100}
               step={1}
-              value={[location.buffer || BUFFERS[LOCATION?.geometry?.type || "point"]]}
+              value={[bufferValue]}
               minStepsBetweenThumbs={1}
               onValueChange={onValueChange}
+              onValueCommit={onValueCommit}
             />
 
             <div className="text-2xs text-muted-foreground flex w-full justify-between font-bold">

--- a/client/src/containers/report/location/create/index.tsx
+++ b/client/src/containers/report/location/create/index.tsx
@@ -1,108 +1,39 @@
 "use client";
 
-import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { ReactNode } from "react";
 
-import * as geodesicAreaOperator from "@arcgis/core/geometry/operators/geodeticAreaOperator";
 import { TooltipPortal } from "@radix-ui/react-tooltip";
 import { useAtom, useSetAtom } from "jotai";
 import { useTranslations } from "next-intl";
 import { LuPen, LuTrash2 } from "react-icons/lu";
 
 import { formatNumber } from "@/lib/formats";
-import {
-  getGeometryWithBuffer,
-  useLocation,
-  useLocationGeometryWithStatus,
-  useLocationTitle,
-} from "@/lib/location";
 
-import { sketchActionAtom, sketchAtom, tmpBboxAtom, useSyncLocation } from "@/app/(frontend)/store";
+import { sketchActionAtom, sketchAtom } from "@/app/(frontend)/store";
 
-import { BUFFERS } from "@/constants/map";
+import { BufferSlider } from "@/containers/report/location/buffer/slider";
+import { useLocationBuffer } from "@/containers/report/location/buffer/use-location-buffer";
 
 import { Button } from "@/components/ui/button";
-import { Slider } from "@/components/ui/slider";
 import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipArrow, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-
-if (!geodesicAreaOperator.isLoaded()) {
-  await geodesicAreaOperator.load();
-}
 
 export default function CreateReport({ children }: { children?: ReactNode }) {
   const t = useTranslations();
   const [sketch, setSketch] = useAtom(sketchAtom);
-
   const setSketchAction = useSetAtom(sketchActionAtom);
-  const setTmpBbox = useSetAtom(tmpBboxAtom);
 
-  const [location, setLocation] = useSyncLocation();
-  const TITLE = useLocationTitle(location);
-  const LOCATION = useLocation(location);
-  const { geometry: GEOMETRY, isCalculating } = useLocationGeometryWithStatus(location);
-
-  const AREA = useMemo(() => {
-    if (!GEOMETRY) return 0;
-    return geodesicAreaOperator.execute(GEOMETRY, { unit: "square-kilometers" });
-  }, [GEOMETRY]);
-
-  // Local buffer value drives the slider/label live while dragging. We commit it to
-  // the (shared) location state once per drag instead of once per pointer-move tick.
-  const committedBuffer =
-    (location && location.type !== "search" ? location.buffer : undefined) ||
-    BUFFERS[LOCATION?.geometry?.type || "point"];
-  const [bufferValue, setBufferValue] = useState(committedBuffer);
-
-  // Latest dragged value, captured synchronously so the commit never reads a stale
-  // React-state value. Radix only fires onValueCommit when its (controlled) value
-  // differs from the slide-start value; on a fast drag the controlled value hasn't
-  // flushed by pointer-up, so onValueCommit gets skipped and the buffer never updates.
-  // A trailing debounce off onValueChange guarantees the final value commits.
-  const pendingBufferRef = useRef(committedBuffer);
-  const commitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Sync local slider state when the committed buffer changes from outside (reset,
-  // upload, edit-location).
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setBufferValue(committedBuffer);
-    pendingBufferRef.current = committedBuffer;
-  }, [committedBuffer]);
-
-  useEffect(() => {
-    return () => {
-      if (commitTimeoutRef.current) clearTimeout(commitTimeoutRef.current);
-    };
-  }, []);
-
-  const commitBuffer = async () => {
-    const value = pendingBufferRef.current;
-    setLocation((prev) => (prev ? { ...prev, buffer: value } : prev));
-
-    const geometry = LOCATION?.geometry;
-    if (!location || !geometry || (location.type !== "point" && location.type !== "polyline")) {
-      return;
-    }
-
-    const gWithBuffer = await getGeometryWithBuffer(geometry, value);
-    if (gWithBuffer?.extent) {
-      setTmpBbox(gWithBuffer.extent);
-    }
-  };
-
-  const onValueChange = (value: number[]) => {
-    pendingBufferRef.current = value[0];
-    setBufferValue(value[0]);
-    if (commitTimeoutRef.current) clearTimeout(commitTimeoutRef.current);
-    commitTimeoutRef.current = setTimeout(commitBuffer, 120);
-  };
-
-  // Radix fires this on release for slow drags / track clicks. Commit immediately and
-  // cancel the pending debounce; reads pendingBufferRef (not the possibly-stale arg).
-  const onValueCommit = () => {
-    if (commitTimeoutRef.current) clearTimeout(commitTimeoutRef.current);
-    commitBuffer();
-  };
+  const {
+    location,
+    setLocation,
+    LOCATION,
+    TITLE,
+    AREA,
+    isCalculating,
+    bufferValue,
+    onValueChange,
+    onValueCommit,
+  } = useLocationBuffer();
 
   if (!location || !LOCATION) return null;
 
@@ -195,33 +126,12 @@ export default function CreateReport({ children }: { children?: ReactNode }) {
       </section>
 
       {location.type !== "search" && LOCATION?.geometry?.type !== "polygon" && (
-        <section className="space-y-2">
-          <div className="flex items-end justify-between">
-            <div className="text-sm leading-none font-semibold text-blue-500">
-              {t("grid-sidebar-report-location-buffer-size")}
-            </div>
-            <div className="text-foreground flex items-center gap-1 text-xs leading-none">
-              {isCalculating && <Spinner className="text-muted-foreground size-3" />}
-              {`${bufferValue} km`}
-            </div>
-          </div>
-          <div className="space-y-1 px-1">
-            <Slider
-              min={1}
-              max={100}
-              step={1}
-              value={[bufferValue]}
-              minStepsBetweenThumbs={1}
-              onValueChange={onValueChange}
-              onValueCommit={onValueCommit}
-            />
-
-            <div className="text-2xs text-muted-foreground flex w-full justify-between font-bold">
-              <span>1 km</span>
-              <span>100 km</span>
-            </div>
-          </div>
-        </section>
+        <BufferSlider
+          bufferValue={bufferValue}
+          isCalculating={isCalculating}
+          onValueChange={onValueChange}
+          onValueCommit={onValueCommit}
+        />
       )}
 
       {/* {location.type !== "search" && (

--- a/client/src/containers/report/location/create/index.tsx
+++ b/client/src/containers/report/location/create/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode, useMemo } from "react";
+import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 
 import * as geodesicAreaOperator from "@arcgis/core/geometry/operators/geodeticAreaOperator";
 import { TooltipPortal } from "@radix-ui/react-tooltip";
@@ -9,11 +9,10 @@ import { useTranslations } from "next-intl";
 import { LuPen, LuTrash2 } from "react-icons/lu";
 
 import { formatNumber } from "@/lib/formats";
-import { useDebounce } from "@/lib/hooks";
 import {
   getGeometryWithBuffer,
   useLocation,
-  useLocationGeometry,
+  useLocationGeometryWithStatus,
   useLocationTitle,
 } from "@/lib/location";
 
@@ -23,6 +22,7 @@ import { BUFFERS } from "@/constants/map";
 
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
+import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipArrow, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 if (!geodesicAreaOperator.isLoaded()) {
@@ -39,34 +39,69 @@ export default function CreateReport({ children }: { children?: ReactNode }) {
   const [location, setLocation] = useSyncLocation();
   const TITLE = useLocationTitle(location);
   const LOCATION = useLocation(location);
-  const GEOMETRY = useLocationGeometry(location);
-
-  const onValueChangeDebounced = useDebounce(() => {
-    if (!location || (location.type !== "point" && location.type !== "polyline")) return;
-    const gWithBuffer = getGeometryWithBuffer(GEOMETRY, location.buffer);
-
-    if (gWithBuffer?.extent) {
-      setTmpBbox(gWithBuffer.extent);
-    }
-  }, 500);
+  const { geometry: GEOMETRY, isCalculating } = useLocationGeometryWithStatus(location);
 
   const AREA = useMemo(() => {
     if (!GEOMETRY) return 0;
     return geodesicAreaOperator.execute(GEOMETRY, { unit: "square-kilometers" });
   }, [GEOMETRY]);
 
-  const onValueChange = (value: number[]) => {
-    setLocation((prev) => {
-      if (prev) {
-        return {
-          ...prev,
-          buffer: value[0],
-        };
-      }
-      return prev;
-    });
+  // Local buffer value drives the slider/label live while dragging. We commit it to
+  // the (shared) location state once per drag instead of once per pointer-move tick.
+  const committedBuffer =
+    (location && location.type !== "search" ? location.buffer : undefined) ||
+    BUFFERS[LOCATION?.geometry?.type || "point"];
+  const [bufferValue, setBufferValue] = useState(committedBuffer);
 
-    onValueChangeDebounced();
+  // Latest dragged value, captured synchronously so the commit never reads a stale
+  // React-state value. Radix only fires onValueCommit when its (controlled) value
+  // differs from the slide-start value; on a fast drag the controlled value hasn't
+  // flushed by pointer-up, so onValueCommit gets skipped and the buffer never updates.
+  // A trailing debounce off onValueChange guarantees the final value commits.
+  const pendingBufferRef = useRef(committedBuffer);
+  const commitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Sync local slider state when the committed buffer changes from outside (reset,
+  // upload, edit-location).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setBufferValue(committedBuffer);
+    pendingBufferRef.current = committedBuffer;
+  }, [committedBuffer]);
+
+  useEffect(() => {
+    return () => {
+      if (commitTimeoutRef.current) clearTimeout(commitTimeoutRef.current);
+    };
+  }, []);
+
+  const commitBuffer = async () => {
+    const value = pendingBufferRef.current;
+    setLocation((prev) => (prev ? { ...prev, buffer: value } : prev));
+
+    const geometry = LOCATION?.geometry;
+    if (!location || !geometry || (location.type !== "point" && location.type !== "polyline")) {
+      return;
+    }
+
+    const gWithBuffer = await getGeometryWithBuffer(geometry, value);
+    if (gWithBuffer?.extent) {
+      setTmpBbox(gWithBuffer.extent);
+    }
+  };
+
+  const onValueChange = (value: number[]) => {
+    pendingBufferRef.current = value[0];
+    setBufferValue(value[0]);
+    if (commitTimeoutRef.current) clearTimeout(commitTimeoutRef.current);
+    commitTimeoutRef.current = setTimeout(commitBuffer, 120);
+  };
+
+  // Radix fires this on release for slow drags / track clicks. Commit immediately and
+  // cancel the pending debounce; reads pendingBufferRef (not the possibly-stale arg).
+  const onValueCommit = () => {
+    if (commitTimeoutRef.current) clearTimeout(commitTimeoutRef.current);
+    commitBuffer();
   };
 
   if (!location || !LOCATION) return null;
@@ -78,7 +113,8 @@ export default function CreateReport({ children }: { children?: ReactNode }) {
           <div className="text-muted-foreground text-sm leading-none font-semibold uppercase">
             {TITLE}
           </div>
-          <div className="text-foreground text-base leading-none font-bold">
+          <div className="text-foreground flex items-center gap-1 text-base leading-none font-bold">
+            {isCalculating && <Spinner className="text-muted-foreground size-3.5" />}
             {formatNumber(AREA, {
               maximumFractionDigits: 0,
             })}{" "}
@@ -164,8 +200,9 @@ export default function CreateReport({ children }: { children?: ReactNode }) {
             <div className="text-sm leading-none font-semibold text-blue-500">
               {t("grid-sidebar-report-location-buffer-size")}
             </div>
-            <div className="text-foreground text-xs leading-none">
-              {`${location.buffer || BUFFERS[LOCATION?.geometry?.type || "point"]} km`}
+            <div className="text-foreground flex items-center gap-1 text-xs leading-none">
+              {isCalculating && <Spinner className="text-muted-foreground size-3" />}
+              {`${bufferValue} km`}
             </div>
           </div>
           <div className="space-y-1 px-1">
@@ -173,9 +210,10 @@ export default function CreateReport({ children }: { children?: ReactNode }) {
               min={1}
               max={100}
               step={1}
-              value={[location.buffer || BUFFERS[LOCATION?.geometry?.type || "point"]]}
+              value={[bufferValue]}
               minStepsBetweenThumbs={1}
               onValueChange={onValueChange}
+              onValueCommit={onValueCommit}
             />
 
             <div className="text-2xs text-muted-foreground flex w-full justify-between font-bold">

--- a/client/src/containers/report/location/search/index.tsx
+++ b/client/src/containers/report/location/search/index.tsx
@@ -56,7 +56,7 @@ export default function SearchC() {
           text: value.label,
         },
         {
-          onSuccess: (data) => {
+          onSuccess: async (data) => {
             setLocation({
               type: "search",
               key: value.key,
@@ -75,7 +75,7 @@ export default function SearchC() {
 
               if (!geo) return;
 
-              const g = getGeometryWithBuffer(geo, BUFFERS[data.type]);
+              const g = await getGeometryWithBuffer(geo, BUFFERS[data.type]);
 
               if (g?.extent) {
                 setTmpBbox(g.extent);

--- a/client/src/lib/location.test.ts
+++ b/client/src/lib/location.test.ts
@@ -1,0 +1,48 @@
+import * as geometryEngineAsync from "@arcgis/core/geometry/geometryEngineAsync";
+
+// location.ts pulls in these hook modules; stub them so importActual doesn't run their
+// module-level side effects (search.ts builds a SearchViewModel on import).
+vi.mock("@/lib/search", () => ({ useGetSearch: vi.fn() }));
+vi.mock("@/lib/query", () => ({ useGetFeatures: vi.fn() }));
+
+// `@/lib/location` is globally mocked in vitest.setup.ts; we want the real implementation here.
+const { getGeometryWithBuffer } =
+  await vi.importActual<typeof import("@/lib/location")>("@/lib/location");
+
+const geodesicBufferAsync = vi.mocked(geometryEngineAsync.geodesicBuffer);
+
+describe("getGeometryWithBuffer", () => {
+  // Regression: uploading a long polyline (e.g. the ~887 km BR-319) froze the app
+  // because geodesicBuffer ran synchronously on the main thread. The buffer must run
+  // off-thread via geometryEngineAsync so the UI stays responsive.
+  it("buffers a polyline off the main thread via geometryEngineAsync", async () => {
+    const buffered = { type: "polygon", rings: [[]] } as unknown as __esri.Polygon;
+    geodesicBufferAsync.mockResolvedValue(buffered);
+
+    const polyline = { type: "polyline" } as unknown as __esri.GeometryUnion;
+    const result = getGeometryWithBuffer(polyline, 30);
+
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).resolves.toBe(buffered);
+    expect(geodesicBufferAsync).toHaveBeenCalledWith(polyline, 30, "kilometers");
+  });
+
+  it("buffers a point off the main thread via geometryEngineAsync", async () => {
+    const buffered = { type: "polygon", rings: [[]] } as unknown as __esri.Polygon;
+    geodesicBufferAsync.mockResolvedValue(buffered);
+
+    const point = { type: "point" } as unknown as __esri.GeometryUnion;
+    await expect(getGeometryWithBuffer(point, 30)).resolves.toBe(buffered);
+    expect(geodesicBufferAsync).toHaveBeenCalledWith(point, 30, "kilometers");
+  });
+
+  it("returns a polygon unchanged without buffering", async () => {
+    const polygon = { type: "polygon" } as __esri.Polygon;
+    await expect(getGeometryWithBuffer(polygon, 30)).resolves.toBe(polygon);
+    expect(geodesicBufferAsync).not.toHaveBeenCalled();
+  });
+
+  it("resolves null for missing geometry", async () => {
+    await expect(getGeometryWithBuffer(null, 30)).resolves.toBeNull();
+  });
+});

--- a/client/src/lib/location.ts
+++ b/client/src/lib/location.ts
@@ -1,6 +1,6 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
-import * as geodesicBufferOperator from "@arcgis/core/geometry/operators/geodesicBufferOperator";
+import * as geometryEngineAsync from "@arcgis/core/geometry/geometryEngineAsync";
 import * as projectOperator from "@arcgis/core/geometry/operators/projectOperator";
 import Point from "@arcgis/core/geometry/Point";
 import Polygon from "@arcgis/core/geometry/Polygon";
@@ -19,10 +19,6 @@ import { BUFFERS } from "@/constants/map";
 
 if (!projectOperator.isLoaded()) {
   await projectOperator.load();
-}
-
-if (!geodesicBufferOperator.isLoaded()) {
-  await geodesicBufferOperator.load();
 }
 
 export type AdministrativeBoundary = {
@@ -114,35 +110,114 @@ export const useLocationTitle = (location?: Location | null) => {
   }, [location, searchData, t]);
 };
 
-export const useLocationGeometry = (
+const srKeyOf = (
+  outSpatialReference?: __esri.SpatialReference | __esri.SpatialReferenceProperties,
+): number | string | null =>
+  (outSpatialReference as __esri.SpatialReferenceProperties | undefined)?.wkid ??
+  (outSpatialReference as __esri.SpatialReferenceProperties | undefined)?.wkt ??
+  null;
+
+// Buffering + projecting runs ArcGIS's geodesicBuffer (now async/off-thread).
+// `useLocationGeometry` is consumed by ~29 components, so without a shared cache the
+// same buffer is recomputed once per component on every location change. Cache the
+// in-flight *promise* by (geometry, buffer, target spatial reference) so concurrent
+// consumers share a single computation and later renders read the resolved value.
+const MAX_GEOMETRY_CACHE_ENTRIES = 50;
+const bufferedGeometryCache = new Map<string, Promise<__esri.Polygon | null>>();
+
+const getBufferedProjectedGeometry = (
+  geometry: __esri.GeometryUnion,
+  buffer: number,
+  outSpatialReference?: __esri.SpatialReference | __esri.SpatialReferenceProperties,
+): Promise<__esri.Polygon | null> => {
+  const geometryJSON = geometry.toJSON();
+  const srKey = srKeyOf(outSpatialReference) ?? geometry.spatialReference?.wkid ?? 102100;
+  const cacheKey = JSON.stringify({ g: geometryJSON, buffer, srKey });
+
+  const cached = bufferedGeometryCache.get(cacheKey);
+  if (cached) return cached;
+
+  const promise = (async () => {
+    const buffered = await getGeometryWithBuffer(geometry, buffer);
+    if (!buffered) return null;
+
+    const SR = new SpatialReference(
+      (outSpatialReference as __esri.SpatialReferenceProperties) ||
+        geometry.spatialReference?.toJSON() || { wkid: 102100 },
+    );
+    const projectedGeom = projectOperator.execute(buffered, SR);
+    return (Array.isArray(projectedGeom) ? projectedGeom[0] : projectedGeom) as __esri.Polygon;
+  })().catch((error) => {
+    // Don't cache failures, so a transient worker error can be retried.
+    bufferedGeometryCache.delete(cacheKey);
+    throw error;
+  });
+
+  if (bufferedGeometryCache.size >= MAX_GEOMETRY_CACHE_ENTRIES) {
+    const oldest = bufferedGeometryCache.keys().next().value;
+    if (oldest !== undefined) bufferedGeometryCache.delete(oldest);
+  }
+  bufferedGeometryCache.set(cacheKey, promise);
+
+  return promise;
+};
+
+// Same as `useLocationGeometry` but also reports whether the buffer is still being
+// computed off-thread, so callers can show a loader. `useLocationGeometry` delegates
+// here and drops the flag, keeping its many consumers unchanged.
+export const useLocationGeometryWithStatus = (
   location?: Location | null,
-  outSpatialReference?: __esri.SpatialReferenceProperties,
+  outSpatialReference?: __esri.SpatialReference | __esri.SpatialReferenceProperties,
 ) => {
   const LOCATION = useLocation(location);
 
-  const GEOMETRY = useMemo(() => {
-    if (LOCATION?.geometry) {
-      const b = location?.type !== "search" ? location?.buffer : BUFFERS[LOCATION.geometry.type];
-      const g = getGeometryWithBuffer(LOCATION.geometry, b || BUFFERS[LOCATION.geometry.type]);
+  // Most call sites pass an inline `{ wkid: 4326 }` literal, which is a new object
+  // every render. Depending on its identity would re-run the buffer on every render,
+  // so key the effect on its wkid/wkt instead of object identity.
+  const outSpatialReferenceKey = srKeyOf(outSpatialReference);
 
-      if (!g) return null;
+  // The buffer is computed asynchronously (off the main thread), so the geometry
+  // resolves after render. Consumers that gate queries on `!!GEOMETRY` simply wait.
+  const [GEOMETRY, setGEOMETRY] = useState<__esri.Polygon | null>(null);
+  const [isCalculating, setIsCalculating] = useState(false);
 
-      const SR = new SpatialReference(
-        outSpatialReference || LOCATION.geometry.spatialReference.toJSON() || { wkid: 102100 },
-      );
-
-      const projectedGeom = projectOperator.execute(g, SR);
-
-      const geom = Array.isArray(projectedGeom) ? projectedGeom[0] : projectedGeom;
-
-      return geom as __esri.Polygon;
+  useEffect(() => {
+    const geometry = LOCATION?.geometry;
+    if (!geometry) {
+      setGEOMETRY(null);
+      setIsCalculating(false);
+      return;
     }
 
-    return null;
-  }, [LOCATION, location, outSpatialReference]);
+    let cancelled = false;
+    const b = location?.type !== "search" ? location?.buffer : BUFFERS[geometry.type];
+    const buffer = b || BUFFERS[geometry.type];
 
-  return GEOMETRY;
+    setIsCalculating(true);
+    getBufferedProjectedGeometry(geometry, buffer, outSpatialReference)
+      .then((geometry) => {
+        if (!cancelled) setGEOMETRY(geometry);
+      })
+      .catch(() => {
+        if (!cancelled) setGEOMETRY(null);
+      })
+      .finally(() => {
+        if (!cancelled) setIsCalculating(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [LOCATION, location, outSpatialReferenceKey]);
+
+  return { geometry: GEOMETRY, isCalculating };
 };
+
+export const useLocationGeometry = (
+  location?: Location | null,
+  outSpatialReference?: __esri.SpatialReference | __esri.SpatialReferenceProperties,
+) => useLocationGeometryWithStatus(location, outSpatialReference).geometry;
 
 export const useLocationGadm = (location?: Location | null) => {
   const GEOMETRY = useLocationGeometry(location);
@@ -192,24 +267,18 @@ export const getGeometryByType = (location: Location) => {
   return null;
 };
 
-export const getGeometryWithBuffer = (
+// Runs ArcGIS's *asynchronous* geodesicBuffer, which offloads the work to a worker
+// instead of blocking the main thread. Buffering a long (~887 km) polyline densifies
+// the offset curve into thousands of vertices and took ~700 ms synchronously, freezing
+// the UI on upload. Keep this async so callers await it off the render path.
+export const getGeometryWithBuffer = async (
   geometry: __esri.GeometryUnion | null,
   buffer: number,
-): __esri.Polygon | null => {
+): Promise<__esri.Polygon | null> => {
   if (!geometry) return null;
 
-  if (geometry.type === "point") {
-    const g = geodesicBufferOperator.execute(geometry, buffer, { unit: "kilometers" });
-
-    if (!g) return null;
-
-    return Array.isArray(g) ? g[0] : g;
-  }
-
-  if (geometry.type === "polyline") {
-    const g = geodesicBufferOperator.execute(geometry, buffer, { unit: "kilometers" });
-
-    if (!g) return null;
+  if (geometry.type === "point" || geometry.type === "polyline") {
+    const g = await geometryEngineAsync.geodesicBuffer(geometry, buffer, "kilometers");
 
     return Array.isArray(g) ? g[0] : g;
   }

--- a/client/src/vitest.setup.ts
+++ b/client/src/vitest.setup.ts
@@ -198,6 +198,26 @@ vi.mock("@arcgis/core/geometry/projection", () => ({
   project: vi.fn(),
 }));
 
+vi.mock("@arcgis/core/geometry/operators/projectOperator", () => ({
+  execute: vi.fn(),
+  load: vi.fn(),
+  isLoaded: vi.fn(),
+}));
+
+vi.mock("@arcgis/core/geometry/geometryEngineAsync", () => ({
+  geodesicBuffer: vi.fn(),
+  geodesicArea: vi.fn(),
+  intersects: vi.fn(),
+}));
+
+vi.mock("@arcgis/core/geometry/SpatialReference", () => ({
+  default: class MockSpatialReference {
+    constructor(properties?: Record<string, unknown>) {
+      Object.assign(this, properties || {});
+    }
+  },
+}));
+
 // Renderers
 vi.mock("@arcgis/core/renderers/SimpleRenderer", () => ({
   default: class MockSimpleRenderer {},


### PR DESCRIPTION
## Summary

Fixes the location buffer behaving badly when adjusting the buffer slider — disappearing, flickering, freezing the UI on long polylines, and (most reported) **not resizing on fast drags**.

- **Off the main thread** (`ba0ab36f`): buffering a long polyline (e.g. the ~887 km / 2,833-vtx BR-319) ran `geodesicBuffer` synchronously and froze the app for ~700ms on every location touch. Moved buffering/intersects/area to `geometryEngineAsync` (worker); shared the in-flight promise across the ~29 `useLocationGeometry` consumers via a cache keyed on geometry+buffer+SR.
- **Commit on release** (`2629974d`): the slider wrote `location.buffer` on every pointer-move, re-firing the async buffer per tick. Drive the slider/label from local state and commit once per drag.
- **No flicker** (`0d5ce54c`): moving buffering off-thread put an `await` between Sketch's eager `bufferRef.removeAll()` and the redraw, so the ring blinked out mid-recompute. `drawBuffer` now owns the buffer layer — clears the old graphic only once the new one is ready — plus a monotonic token so a stale async result can't clobber a newer one.
- **Reliable commit on fast drags** (`50821b97`): the slider's controlled value is React state set in `onValueChange`; on a fast drag it hasn't flushed by pointer-up, so Radix sees no change vs slide-start and **skips `onValueCommit` entirely** → `location.buffer` never updates and the ring keeps the old size (label looked right because it flushes a beat later). A track click commits via a different path, so it was always reliable. Now each change is captured in a ref and committed on a trailing debounce, independent of whether Radix fires `onValueCommit`.
- Reverted an interim sync-fallback commit (`0b07caa6` → `79f95708`): its premise (worker rejection) never occurred in testing.

## Test plan

- [x] Upload a long polyline (BR-319, 2,833 vtx) — app stays responsive (no main-thread freeze) while buffering.
- [x] Draw a **point**, **fast-drag** the buffer slider, release — ring resizes every time (not just on track clicks).
- [x] Drag the slider — ring swaps to the new size without blinking out.
- [x] Track-click the slider — still commits (regression check).
- [x] Confirm the SELECTED AREA value tracks the buffer value.
- [x] Note: the heavy 2,833-vtx line still has ~1–2s compute latency with no pending indicator (separate follow-up).