### PR TITLE
feat(client): add Topics, Subtopics and Indicators CMS collections

### DIFF
--- a/client/src/cms/access/catalogue.ts
+++ b/client/src/cms/access/catalogue.ts
@@ -1,0 +1,19 @@
+import type { Access } from "payload";
+
+/**
+ * Read access for the catalogue collections (Topics, Subtopics, Indicators).
+ *
+ * These collections enable `versions: { drafts: true }`, which means Payload keeps the
+ * latest version — draft *or* published — in the main table. A plain `anyoneAccess` read
+ * would therefore leak unpublished content to any caller once phase 2 seeds data, so
+ * every non-admin caller (anonymous or signed in) is constrained to published documents.
+ *
+ * Admins are the deliberate exception, not an oversight: Payload's admin UI reuses this
+ * same `read` access function, so an admin who could not read drafts could neither see
+ * nor edit the drafts they author. Do not simplify this back to `anyoneAccess`.
+ */
+export const publishedOrAdminAccess: Access = ({ req: { user } }) => {
+  if (user?.collection === "admins") return true;
+
+  return { _status: { equals: "published" } };
+};

--- a/client/src/cms/collections/Indicators.ts
+++ b/client/src/cms/collections/Indicators.ts
@@ -1,0 +1,63 @@
+import type { CollectionConfig } from "payload";
+
+import { ResourceField } from "@/cms/fields/resource";
+import { warnOnVisualizationMismatch } from "@/cms/hooks/indicator-visualization";
+
+import { catalogueAccess, legacyIdField } from "./Topics";
+
+export const Indicators: CollectionConfig = {
+  slug: "indicators",
+  admin: {
+    group: "Catalogue",
+    useAsTitle: "name",
+    defaultColumns: ["legacy_id", "name", "subtopic", "_status"],
+  },
+  access: catalogueAccess,
+  versions: { drafts: true },
+  fields: [
+    legacyIdField,
+    {
+      name: "order",
+      type: "number",
+      required: true,
+      admin: {
+        description:
+          "Display order within a subtopic. Not the same as legacy_id — they diverge on some rows.",
+      },
+    },
+    { name: "subtopic", type: "relationship", relationTo: "subtopics", required: true },
+    { name: "name", type: "text", localized: true, required: true },
+    {
+      name: "unit",
+      type: "text",
+      localized: true,
+      admin: { description: "e.g. km², m. Empty on 63 of 164 rows." },
+    },
+    { name: "description_short", type: "text", localized: true, required: true },
+    {
+      name: "description",
+      type: "textarea",
+      localized: true,
+      admin: { description: "Markdown. Rendered with react-markdown in containers/info." },
+    },
+    {
+      name: "visualization_types",
+      type: "select",
+      hasMany: true,
+      options: [
+        { label: "Map", value: "map" },
+        { label: "Table", value: "table" },
+        { label: "Chart", value: "chart" },
+        { label: "Numeric", value: "numeric" },
+      ],
+      admin: {
+        description:
+          "Which widgets this indicator offers. Deliberately explicit, not derived: deriving would change 18 of 164 rows. Empty for all h3 indicators.",
+      },
+    },
+    ResourceField,
+  ],
+  hooks: {
+    beforeChange: [warnOnVisualizationMismatch],
+  },
+};

--- a/client/src/cms/collections/Subtopics.ts
+++ b/client/src/cms/collections/Subtopics.ts
@@ -1,0 +1,40 @@
+import type { CollectionConfig } from "payload";
+
+import { DefaultVisualizationField } from "@/cms/fields/default-visualization";
+
+import { catalogueAccess, legacyIdField } from "./Topics";
+
+export const Subtopics: CollectionConfig = {
+  slug: "subtopics",
+  admin: {
+    group: "Catalogue",
+    useAsTitle: "name",
+    defaultColumns: ["legacy_id", "name", "topic", "_status"],
+  },
+  access: catalogueAccess,
+  versions: { drafts: true },
+  fields: [
+    legacyIdField,
+    { name: "topic", type: "relationship", relationTo: "topics", required: true },
+    {
+      name: "name",
+      type: "text",
+      localized: true,
+      // Required by contract. Payload validates `required` against the request locale, so
+      // seeding English-only content still succeeds and reads fall back to en. The ES/PT
+      // tabs will refuse to save until phase 2 seeds the 28 translations — by design.
+      required: true,
+      admin: {
+        description:
+          "English only in the source data. ES and PT translations are seeded in phase 2; reads fall back to en until then.",
+      },
+    },
+    {
+      name: "description",
+      type: "textarea",
+      localized: true,
+      admin: { description: "Markdown. Empty on every row in the source data." },
+    },
+    DefaultVisualizationField,
+  ],
+};

--- a/client/src/cms/collections/Topics.ts
+++ b/client/src/cms/collections/Topics.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig, Field } from "payload";
 
 import { adminAccess } from "@/cms/access/admin";
-import { anyoneAccess } from "@/cms/access/anyone";
+import { publishedOrAdminAccess } from "@/cms/access/catalogue";
 import { DefaultVisualizationField } from "@/cms/fields/default-visualization";
 
 /**
@@ -29,8 +29,9 @@ export const legacyIdField: Field = {
 };
 
 export const catalogueAccess = {
-  // The catalogue is already public today, shipped as a bundled JSON in the client.
-  read: anyoneAccess,
+  // Published-only for everyone except admins; see the comment on
+  // `publishedOrAdminAccess` for why admins are exempt.
+  read: publishedOrAdminAccess,
   create: adminAccess,
   update: adminAccess,
   delete: adminAccess,

--- a/client/src/cms/collections/Topics.ts
+++ b/client/src/cms/collections/Topics.ts
@@ -1,0 +1,64 @@
+import type { CollectionConfig, Field } from "payload";
+
+import { adminAccess } from "@/cms/access/admin";
+import { anyoneAccess } from "@/cms/access/anyone";
+import { DefaultVisualizationField } from "@/cms/fields/default-visualization";
+
+/**
+ * The numeric id from the original datum JSON.
+ *
+ * Still an external contract: `cms/fields/topics.ts` stores raw `topic_id` /
+ * `indicator_id` numbers on every reports row, and `defaultTopics` is a nuqs URL param
+ * (app/(frontend)/store.ts). The reports migration is deliberately out of scope, so this
+ * value must never change.
+ *
+ * Immutability uses field access rather than `admin.readOnly`, which would also block the
+ * phase-2 seed from setting it.
+ */
+export const legacyIdField: Field = {
+  name: "legacy_id",
+  type: "number",
+  required: true,
+  unique: true,
+  index: true,
+  access: { update: () => false },
+  admin: {
+    description:
+      "Numeric id from the original datum JSON. Referenced by existing reports rows and by the defaultTopics URL param. Never change it.",
+  },
+};
+
+export const catalogueAccess = {
+  // The catalogue is already public today, shipped as a bundled JSON in the client.
+  read: anyoneAccess,
+  create: adminAccess,
+  update: adminAccess,
+  delete: adminAccess,
+};
+
+export const Topics: CollectionConfig = {
+  slug: "topics",
+  admin: {
+    group: "Catalogue",
+    useAsTitle: "name",
+    defaultColumns: ["legacy_id", "name", "_status"],
+  },
+  access: catalogueAccess,
+  versions: { drafts: true },
+  fields: [
+    legacyIdField,
+    { name: "name", type: "text", localized: true, required: true },
+    {
+      name: "description",
+      type: "textarea",
+      localized: true,
+      admin: { description: "Markdown. Rendered with react-markdown." },
+    },
+    {
+      name: "image",
+      type: "text",
+      admin: { description: "Path under client/public, e.g. /images/topics/territory.webp" },
+    },
+    DefaultVisualizationField,
+  ],
+};

--- a/client/src/cms/collections/indicators.test.ts
+++ b/client/src/cms/collections/indicators.test.ts
@@ -1,0 +1,123 @@
+import type { SelectField } from "payload";
+
+import INDICATORS from "@/../datum/indicators.json";
+import SUBTOPICS from "@/../datum/subtopics.json";
+import { findFieldByName, isEmptyValue } from "@/cms/test-utils/find-field";
+
+import { Indicators } from "./Indicators";
+
+const LOCALES = ["en", "es", "pt"] as const;
+
+type SourceIndicator = Record<string, unknown> & {
+  id: number;
+  subtopic_id: number;
+  visualization_types: string[];
+};
+
+const indicators = INDICATORS as unknown as SourceIndicator[];
+const subtopicIds = new Set((SUBTOPICS as unknown as { id: number }[]).map((s) => s.id));
+
+describe("Indicators", () => {
+  test("uses the expected slug and enables drafts", () => {
+    expect(Indicators.slug).toBe("indicators");
+    expect(Indicators.versions).toEqual({ drafts: true });
+  });
+
+  test("is publicly readable but only writable by admins", () => {
+    const anonymous = { req: { user: null } } as never;
+    const admin = { req: { user: { collection: "admins" } } } as never;
+
+    expect(Indicators.access?.read?.(anonymous)).toBe(true);
+    expect(Indicators.access?.update?.(anonymous)).toBe(false);
+    expect(Indicators.access?.update?.(admin)).toBe(true);
+  });
+
+  test("keeps legacy_id required, unique and immutable", () => {
+    const legacyId = findFieldByName(Indicators.fields, "legacy_id");
+
+    expect(legacyId).toMatchObject({ type: "number", required: true, unique: true, index: true });
+    expect(legacyId?.access?.update?.({} as never)).toBe(false);
+  });
+
+  test("keeps order separate from legacy_id, since they diverge in the source data", () => {
+    expect(findFieldByName(Indicators.fields, "order")).toMatchObject({
+      type: "number",
+      required: true,
+    });
+    expect(indicators.some((indicator) => indicator.id !== indicator.order)).toBe(true);
+  });
+
+  test("relates to subtopics rather than storing a numeric subtopic_id", () => {
+    expect(findFieldByName(Indicators.fields, "subtopic")).toMatchObject({
+      type: "relationship",
+      relationTo: "subtopics",
+      required: true,
+    });
+    expect(findFieldByName(Indicators.fields, "subtopic_id")).toBeUndefined();
+  });
+
+  test("every subtopic_id in the source data resolves to a subtopic", () => {
+    expect(indicators.filter((indicator) => !subtopicIds.has(indicator.subtopic_id))).toEqual([]);
+  });
+
+  test("localizes the four text groups and drops the _en/_es/_pt triples", () => {
+    for (const name of ["name", "unit", "description", "description_short"]) {
+      expect(findFieldByName(Indicators.fields, name)?.localized).toBe(true);
+    }
+
+    for (const name of ["name_en", "unit_es", "description_pt", "description_short_en"]) {
+      expect(findFieldByName(Indicators.fields, name)).toBeUndefined();
+    }
+  });
+
+  test("drops the dead Active field", () => {
+    expect(findFieldByName(Indicators.fields, "Active")).toBeUndefined();
+    // Dead weight: zero references in client/src and `1` on every row.
+    expect(indicators.every((indicator) => indicator.Active === 1)).toBe(true);
+  });
+
+  test("requires only the localized fields populated in all three locales", () => {
+    const violations: string[] = [];
+
+    for (const name of ["name", "unit", "description", "description_short"]) {
+      const field = findFieldByName(Indicators.fields, name);
+      if (!field?.required) continue;
+
+      for (const indicator of indicators) {
+        for (const locale of LOCALES) {
+          if (!isEmptyValue(indicator[`${name}_${locale}`])) continue;
+          violations.push(`indicator ${indicator.id}: required "${name}_${locale}" is empty`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  test("keeps visualization_types explicit, offering every value used in the data", () => {
+    // `hasMany` and `options` are select-specific, so narrow rather than widen NamedField.
+    const field = findFieldByName(Indicators.fields, "visualization_types") as SelectField;
+
+    expect(field.hasMany).toBe(true);
+
+    const offered = new Set(
+      field.options.map((option) => (typeof option === "string" ? option : option.value)),
+    );
+    const used = new Set(indicators.flatMap((indicator) => indicator.visualization_types));
+
+    expect([...used].filter((type) => !offered.has(type))).toEqual([]);
+  });
+
+  test("carries the resource blocks field, holding exactly one resource", () => {
+    expect(findFieldByName(Indicators.fields, "resource")).toMatchObject({
+      type: "blocks",
+      required: true,
+      minRows: 1,
+      maxRows: 1,
+    });
+  });
+
+  test("registers the non-blocking visualization mismatch warning", () => {
+    expect(Indicators.hooks?.beforeChange).toHaveLength(1);
+  });
+});

--- a/client/src/cms/collections/indicators.test.ts
+++ b/client/src/cms/collections/indicators.test.ts
@@ -24,11 +24,18 @@ describe("Indicators", () => {
     expect(Indicators.versions).toEqual({ drafts: true });
   });
 
-  test("is publicly readable but only writable by admins", () => {
+  test("restricts read to published documents for everyone except admins", () => {
     const anonymous = { req: { user: null } } as never;
     const admin = { req: { user: { collection: "admins" } } } as never;
+    const signedInUser = { req: { user: { collection: "users" } } } as never;
 
-    expect(Indicators.access?.read?.(anonymous)).toBe(true);
+    expect(Indicators.access?.read?.(anonymous)).toEqual({ _status: { equals: "published" } });
+    // The owner-directed case: a signed-in non-admin still only sees published content.
+    expect(Indicators.access?.read?.(signedInUser)).toEqual({
+      _status: { equals: "published" },
+    });
+    expect(Indicators.access?.read?.(admin)).toBe(true);
+
     expect(Indicators.access?.update?.(anonymous)).toBe(false);
     expect(Indicators.access?.update?.(admin)).toBe(true);
   });

--- a/client/src/cms/collections/indicators.test.ts
+++ b/client/src/cms/collections/indicators.test.ts
@@ -2,6 +2,7 @@ import type { SelectField } from "payload";
 
 import INDICATORS from "@/../datum/indicators.json";
 import SUBTOPICS from "@/../datum/subtopics.json";
+import { warnOnVisualizationMismatch } from "@/cms/hooks/indicator-visualization";
 import { findFieldByName, isEmptyValue } from "@/cms/test-utils/find-field";
 
 import { Indicators } from "./Indicators";
@@ -119,5 +120,13 @@ describe("Indicators", () => {
 
   test("registers the non-blocking visualization mismatch warning", () => {
     expect(Indicators.hooks?.beforeChange).toHaveLength(1);
+    expect(Indicators.hooks?.beforeChange?.[0]).toBe(warnOnVisualizationMismatch);
+  });
+
+  test("pins which localized fields are required", () => {
+    expect(findFieldByName(Indicators.fields, "name")?.required).toBe(true);
+    expect(findFieldByName(Indicators.fields, "description_short")?.required).toBe(true);
+    expect(findFieldByName(Indicators.fields, "unit")?.required).toBeFalsy();
+    expect(findFieldByName(Indicators.fields, "description")?.required).toBeFalsy();
   });
 });

--- a/client/src/cms/collections/topics.test.ts
+++ b/client/src/cms/collections/topics.test.ts
@@ -41,12 +41,17 @@ describe.each([
     expect(collection.versions).toEqual({ drafts: true });
   });
 
-  test("is publicly readable but only writable by admins", () => {
+  test("restricts read to published documents for everyone except admins", () => {
     const anonymous = { req: { user: null } } as never;
     const admin = { req: { user: { collection: "admins" } } } as never;
     const signedInUser = { req: { user: { collection: "users" } } } as never;
 
-    expect(collection.access?.read?.(anonymous)).toBe(true);
+    expect(collection.access?.read?.(anonymous)).toEqual({ _status: { equals: "published" } });
+    // The owner-directed case: a signed-in non-admin still only sees published content.
+    expect(collection.access?.read?.(signedInUser)).toEqual({
+      _status: { equals: "published" },
+    });
+    expect(collection.access?.read?.(admin)).toBe(true);
 
     for (const operation of ["create", "update", "delete"] as const) {
       expect(collection.access?.[operation]?.(anonymous)).toBe(false);

--- a/client/src/cms/collections/topics.test.ts
+++ b/client/src/cms/collections/topics.test.ts
@@ -1,0 +1,169 @@
+import type { CollectionConfig } from "payload";
+
+import SUBTOPICS from "@/../datum/subtopics.json";
+import TOPICS from "@/../datum/topics.json";
+import { findFieldByName, isEmptyValue, namedFields } from "@/cms/test-utils/find-field";
+
+import { Subtopics } from "./Subtopics";
+import { Topics } from "./Topics";
+
+const LOCALES = ["en", "es", "pt"] as const;
+
+type SourceRow = Record<string, unknown> & { id: number };
+
+const topics = TOPICS as unknown as SourceRow[];
+const subtopics = SUBTOPICS as unknown as SourceRow[];
+
+const localizedRequiredFields = (collection: CollectionConfig) =>
+  namedFields(collection.fields).filter((field) => field.required && field.localized);
+
+/**
+ * Missing translations per collection, as `{ "<field>_<locale>": count }`.
+ *
+ * These are contract gaps, not schema bugs: `required` says the field must eventually be
+ * filled, and phase 2 seeds the missing values. The test fails if the gap grows or shrinks
+ * unexpectedly, which is what makes the debt visible instead of forgotten.
+ */
+const EXPECTED_TRANSLATION_DEBT: Record<string, Record<string, number>> = {
+  topics: {},
+  subtopics: { name_es: 28, name_pt: 28 },
+};
+
+describe.each([
+  { label: "Topics", collection: Topics, slug: "topics", rows: topics },
+  { label: "Subtopics", collection: Subtopics, slug: "subtopics", rows: subtopics },
+])("$label", ({ collection, slug, rows }) => {
+  test("uses the expected slug", () => {
+    expect(collection.slug).toBe(slug);
+  });
+
+  test("enables drafts so a bad catalogue edit can be rolled back", () => {
+    expect(collection.versions).toEqual({ drafts: true });
+  });
+
+  test("is publicly readable but only writable by admins", () => {
+    const anonymous = { req: { user: null } } as never;
+    const admin = { req: { user: { collection: "admins" } } } as never;
+    const signedInUser = { req: { user: { collection: "users" } } } as never;
+
+    expect(collection.access?.read?.(anonymous)).toBe(true);
+
+    for (const operation of ["create", "update", "delete"] as const) {
+      expect(collection.access?.[operation]?.(anonymous)).toBe(false);
+      expect(collection.access?.[operation]?.(signedInUser)).toBe(false);
+      expect(collection.access?.[operation]?.(admin)).toBe(true);
+    }
+  });
+
+  test("groups under Catalogue in the admin UI", () => {
+    expect(collection.admin?.group).toBe("Catalogue");
+    expect(collection.admin?.useAsTitle).toBe("name");
+  });
+
+  test("keeps legacy_id required, unique and immutable", () => {
+    const legacyId = findFieldByName(collection.fields, "legacy_id");
+
+    expect(legacyId?.type).toBe("number");
+    expect(legacyId).toMatchObject({ required: true, unique: true, index: true });
+    expect(legacyId?.access?.update?.({} as never)).toBe(false);
+  });
+
+  test("every legacy_id in the source data is a unique number", () => {
+    const ids = rows.map((row) => row.id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.every((id) => typeof id === "number")).toBe(true);
+  });
+
+  test("localizes name and description instead of keeping _en/_es/_pt triples", () => {
+    expect(findFieldByName(collection.fields, "name")?.localized).toBe(true);
+    expect(findFieldByName(collection.fields, "description")?.localized).toBe(true);
+    expect(findFieldByName(collection.fields, "name_en")).toBeUndefined();
+    expect(findFieldByName(collection.fields, "description_pt")).toBeUndefined();
+  });
+
+  test("drops the dead Numerotation field", () => {
+    expect(findFieldByName(collection.fields, "Numerotation")).toBeUndefined();
+  });
+
+  test("carries the shared default_visualization array", () => {
+    expect(findFieldByName(collection.fields, "default_visualization")?.type).toBe("array");
+  });
+
+  test("every required localized field has an `en` value on every row, so the seed can create it", () => {
+    // Payload validates `required` against the request locale only. Seeding writes `en`,
+    // so a populated `en` value is the invariant that makes phase 2 possible.
+    const violations: string[] = [];
+
+    for (const field of localizedRequiredFields(collection)) {
+      for (const row of rows) {
+        if (!isEmptyValue(row[`${field.name}_en`])) continue;
+        violations.push(`${slug} ${row.id}: required "${field.name}_en" is empty`);
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  test("declares the phase-2 translation debt for required localized fields", () => {
+    // Not a defect: `required` states the contract. These are the gaps phase 2 must seed
+    // before the ES/PT admin tabs become saveable.
+    const debt: Record<string, number> = {};
+
+    for (const field of localizedRequiredFields(collection)) {
+      for (const locale of LOCALES) {
+        const missing = rows.filter((row) => isEmptyValue(row[`${field.name}_${locale}`])).length;
+        if (missing > 0) debt[`${field.name}_${locale}`] = missing;
+      }
+    }
+
+    expect(debt).toEqual(EXPECTED_TRANSLATION_DEBT[slug]);
+  });
+});
+
+describe("Subtopics", () => {
+  test("relates to topics rather than storing a numeric topic_id", () => {
+    const topic = findFieldByName(Subtopics.fields, "topic");
+
+    expect(topic).toMatchObject({ type: "relationship", relationTo: "topics", required: true });
+    expect(findFieldByName(Subtopics.fields, "topic_id")).toBeUndefined();
+  });
+
+  test("every topic_id in the source data resolves to a topic", () => {
+    const topicIds = new Set(topics.map((topic) => topic.id));
+
+    expect(subtopics.filter((subtopic) => !topicIds.has(subtopic.topic_id as number))).toEqual([]);
+  });
+
+  test("requires name, and every row has an English value so the seed can create it", () => {
+    expect(findFieldByName(Subtopics.fields, "name")).toMatchObject({
+      required: true,
+      localized: true,
+    });
+    expect(subtopics.every((subtopic) => !isEmptyValue(subtopic.name_en))).toBe(true);
+  });
+
+  test("leaves description optional, since it is empty in every locale on every row", () => {
+    expect(findFieldByName(Subtopics.fields, "description")?.required).toBeFalsy();
+    expect(
+      subtopics.every((subtopic) =>
+        LOCALES.every((locale) => isEmptyValue(subtopic[`description_${locale}`])),
+      ),
+    ).toBe(true);
+  });
+
+  test("omits image, which is empty on every subtopic", () => {
+    expect(findFieldByName(Subtopics.fields, "image")).toBeUndefined();
+    expect(subtopics.every((subtopic) => isEmptyValue(subtopic.image))).toBe(true);
+  });
+});
+
+describe("Topics", () => {
+  test("requires name, which is populated in all three locales on all 9 rows", () => {
+    expect(findFieldByName(Topics.fields, "name")?.required).toBe(true);
+  });
+
+  test("keeps image as a path string rather than a Media upload", () => {
+    expect(findFieldByName(Topics.fields, "image")?.type).toBe("text");
+  });
+});

--- a/client/src/cms/fields/default-visualization.test.ts
+++ b/client/src/cms/fields/default-visualization.test.ts
@@ -1,0 +1,95 @@
+import type { RadioField } from "payload";
+
+import INDICATORS from "@/../datum/indicators.json";
+import SUBTOPICS from "@/../datum/subtopics.json";
+import TOPICS from "@/../datum/topics.json";
+import { findFieldByName, isEmptyValue, namedFields } from "@/cms/test-utils/find-field";
+
+import { DefaultVisualizationField } from "./default-visualization";
+
+type SourceVisualization = Record<string, unknown> & { indicator_id: number; type: string };
+type SourceGroup = { id: number; default_visualization: SourceVisualization[] };
+
+const groups: { collection: string; rows: SourceGroup[] }[] = [
+  { collection: "topics", rows: TOPICS as unknown as SourceGroup[] },
+  { collection: "subtopics", rows: SUBTOPICS as unknown as SourceGroup[] },
+];
+
+/** Documented defect from the spec (§9): subtopic 26 points at a nonexistent indicator 55. */
+const KNOWN_DANGLING = ["subtopics 26 -> indicator 55"];
+
+const arrayFields = () => {
+  const field = DefaultVisualizationField;
+  if (field.type !== "array") throw new Error("DefaultVisualizationField must be an array field");
+  return field.fields;
+};
+
+describe("DefaultVisualizationField", () => {
+  test("is an array field named default_visualization", () => {
+    expect(DefaultVisualizationField.type).toBe("array");
+    expect(findFieldByName([DefaultVisualizationField], "default_visualization")).toBeDefined();
+  });
+
+  test("references indicators by relationship, not by numeric id", () => {
+    const indicator = findFieldByName(arrayFields(), "indicator");
+
+    expect(indicator?.type).toBe("relationship");
+    expect(findFieldByName(arrayFields(), "indicator_id")).toBeUndefined();
+  });
+
+  test("drops the source JSON's redundant inner id", () => {
+    expect(findFieldByName(arrayFields(), "id")).toBeUndefined();
+  });
+
+  test("offers every visualization type used in the source data", () => {
+    // `options` is radio-specific, so narrow to RadioField rather than widening NamedField.
+    const typeField = findFieldByName(arrayFields(), "type") as RadioField;
+    const offered = new Set(
+      typeField.options.map((option) => (typeof option === "string" ? option : option.value)),
+    );
+    const used = new Set(
+      groups.flatMap(({ rows }) => rows.flatMap((row) => row.default_visualization.map((v) => v.type))),
+    );
+
+    expect([...used].filter((type) => !offered.has(type))).toEqual([]);
+  });
+
+  test("every required field is present on every source visualization entry", () => {
+    const violations: string[] = [];
+    const required = namedFields(arrayFields()).filter((field) => field.required);
+
+    for (const { collection, rows } of groups) {
+      for (const row of rows) {
+        for (const [index, visualization] of row.default_visualization.entries()) {
+          for (const field of required) {
+            // `indicator` is the relationship replacing the source's `indicator_id`.
+            const key = field.name === "indicator" ? "indicator_id" : field.name;
+            if (!isEmptyValue(visualization[key])) continue;
+
+            violations.push(`${collection} ${row.id}[${index}]: missing "${key}"`);
+          }
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  test("only the documented dangling indicator reference exists", () => {
+    const indicatorIds = new Set(
+      (INDICATORS as unknown as { id: number }[]).map((indicator) => indicator.id),
+    );
+    const dangling: string[] = [];
+
+    for (const { collection, rows } of groups) {
+      for (const row of rows) {
+        for (const visualization of row.default_visualization) {
+          if (indicatorIds.has(visualization.indicator_id)) continue;
+          dangling.push(`${collection} ${row.id} -> indicator ${visualization.indicator_id}`);
+        }
+      }
+    }
+
+    expect(dangling).toEqual(KNOWN_DANGLING);
+  });
+});

--- a/client/src/cms/fields/default-visualization.test.ts
+++ b/client/src/cms/fields/default-visualization.test.ts
@@ -77,6 +77,32 @@ describe("DefaultVisualizationField", () => {
     expect(violations).toEqual([]);
   });
 
+  test.each(["basemapId", "opacity"] as const)(
+    "clears %s on save when the widget is not a map",
+    (fieldName) => {
+      const field = findFieldByName(arrayFields(), fieldName);
+      const beforeChange = field?.hooks?.beforeChange?.[0];
+
+      expect(beforeChange).toBeDefined();
+      expect(
+        beforeChange?.({ value: "some-value", siblingData: { type: "chart" } } as never),
+      ).toBeNull();
+    },
+  );
+
+  test.each(["basemapId", "opacity"] as const)(
+    "keeps %s on save when the widget is a map",
+    (fieldName) => {
+      const field = findFieldByName(arrayFields(), fieldName);
+      const beforeChange = field?.hooks?.beforeChange?.[0];
+
+      expect(beforeChange).toBeDefined();
+      expect(beforeChange?.({ value: "some-value", siblingData: { type: "map" } } as never)).toBe(
+        "some-value",
+      );
+    },
+  );
+
   test("only the documented dangling indicator reference exists", () => {
     const indicatorIds = new Set(
       (INDICATORS as unknown as { id: number }[]).map((indicator) => indicator.id),

--- a/client/src/cms/fields/default-visualization.test.ts
+++ b/client/src/cms/fields/default-visualization.test.ts
@@ -48,7 +48,9 @@ describe("DefaultVisualizationField", () => {
       typeField.options.map((option) => (typeof option === "string" ? option : option.value)),
     );
     const used = new Set(
-      groups.flatMap(({ rows }) => rows.flatMap((row) => row.default_visualization.map((v) => v.type))),
+      groups.flatMap(({ rows }) =>
+        rows.flatMap((row) => row.default_visualization.map((v) => v.type)),
+      ),
     );
 
     expect([...used].filter((type) => !offered.has(type))).toEqual([]);

--- a/client/src/cms/fields/default-visualization.ts
+++ b/client/src/cms/fields/default-visualization.ts
@@ -7,6 +7,19 @@ const showForMapsOnly = {
 };
 
 /**
+ * Mirrors `cms/fields/topics.ts` (the Reports collection's equivalent field): clears
+ * `basemapId`/`opacity` on save when the widget is not a map, so switching a widget's
+ * `type` away from `map` doesn't leave a stale value behind that the UI no longer shows.
+ */
+const clearWhenNotMap = ({
+  value,
+  siblingData,
+}: {
+  value?: unknown;
+  siblingData?: { type?: string };
+}) => (siblingData?.type !== "map" ? null : value);
+
+/**
  * The pre-configured widget layout for a topic or subtopic.
  *
  * Deliberately NOT shared with `cms/fields/topics.ts` (used by Reports): that field
@@ -52,6 +65,7 @@ export const DefaultVisualizationField: Field = {
       options: BASEMAPS.map((basemap) => ({ label: basemap.id, value: basemap.id })),
       defaultValue: "gray-vector",
       admin: showForMapsOnly,
+      hooks: { beforeChange: [clearWhenNotMap] },
     },
     {
       name: "opacity",
@@ -59,6 +73,7 @@ export const DefaultVisualizationField: Field = {
       required: false,
       defaultValue: 1,
       admin: showForMapsOnly,
+      hooks: { beforeChange: [clearWhenNotMap] },
     },
   ],
 };

--- a/client/src/cms/fields/default-visualization.ts
+++ b/client/src/cms/fields/default-visualization.ts
@@ -1,0 +1,64 @@
+import type { Field } from "payload";
+
+import { BASEMAPS } from "@/constants/basemaps";
+
+const showForMapsOnly = {
+  condition: (_: unknown, siblingData: { type?: string }) => siblingData.type === "map",
+};
+
+/**
+ * The pre-configured widget layout for a topic or subtopic.
+ *
+ * Deliberately NOT shared with `cms/fields/topics.ts` (used by Reports): that field
+ * stores `indicator_id` as a raw number to match untouched reports data, whereas this
+ * one uses a relationship. Unifying them belongs to the deferred reports migration.
+ */
+export const DefaultVisualizationField: Field = {
+  name: "default_visualization",
+  type: "array",
+  labels: { singular: "Default visualization", plural: "Default visualizations" },
+  fields: [
+    {
+      name: "indicator",
+      type: "relationship",
+      relationTo: "indicators",
+      required: true,
+    },
+    {
+      name: "type",
+      type: "radio",
+      required: true,
+      options: [
+        { label: "Map", value: "map" },
+        { label: "Chart", value: "chart" },
+        { label: "Table", value: "table" },
+        { label: "Numeric", value: "numeric" },
+        { label: "Custom", value: "custom" },
+        { label: "Ai", value: "ai" },
+      ],
+      admin: {
+        description:
+          "The source data only uses map, numeric, chart and table; custom and ai exist to match Reports.",
+      },
+    },
+    { name: "x", label: "X Coordinate", type: "number", required: true },
+    { name: "y", label: "Y Coordinate", type: "number", required: true },
+    { name: "w", label: "Width", type: "number", required: true },
+    { name: "h", label: "Height", type: "number", required: true },
+    {
+      name: "basemapId",
+      type: "radio",
+      required: false,
+      options: BASEMAPS.map((basemap) => ({ label: basemap.id, value: basemap.id })),
+      defaultValue: "gray-vector",
+      admin: showForMapsOnly,
+    },
+    {
+      name: "opacity",
+      type: "number",
+      required: false,
+      defaultValue: 1,
+      admin: showForMapsOnly,
+    },
+  ],
+};

--- a/client/src/cms/fields/resource.test.ts
+++ b/client/src/cms/fields/resource.test.ts
@@ -1,4 +1,4 @@
-import type { Block } from "payload";
+import type { Block, Field } from "payload";
 
 import INDICATORS from "@/../datum/indicators.json";
 import {
@@ -40,6 +40,50 @@ const KEYS_DROPPED_BY_TYPE: Record<string, string[]> = {
 };
 
 const blocksBySlug = new Map<string, Block>(RESOURCE_BLOCKS.map((block) => [block.slug, block]));
+
+/**
+ * Recurses into `group` and `array` fields (fanning out once per array item) to find nested
+ * `required` fields that are empty in `data`. Deliberately kept local to this file rather than
+ * added to `find-field.ts`: it interleaves schema (`field.required`) with real data (fanning out
+ * over array *items*, not just the array field's own shape), which is business logic specific to
+ * this conformance check, not something the other three consumers of `find-field.ts` need.
+ *
+ * `namedFields`/`fieldNames` stay deliberately shallow (see their docstrings) — this reaches the
+ * fields they cannot: `legend.type`, `legend.items`, `legend.items[].label`,
+ * `legend.items[].color`, `popupTemplate.fieldInfos[].fieldName` and
+ * `popupTemplate.fieldInfos[].label`. These are the schema's only *nested* `required`
+ * constraints.
+ *
+ * Top-level (depth 0) required fields are intentionally NOT reported here — that's the "every
+ * required block field is non-empty on every row of that type" test's job. `path` starts empty
+ * and only becomes truthy once we've descended at least one level, which is what gates the check.
+ */
+const collectNestedRequiredViolations = (fields: Field[], data: unknown, path = ""): string[] => {
+  const violations: string[] = [];
+  const record = data && typeof data === "object" ? (data as Record<string, unknown>) : {};
+
+  for (const field of namedFields(fields)) {
+    const value = record[field.name];
+    const fieldPath = path ? `${path}.${field.name}` : field.name;
+
+    if (path && field.required && isEmptyValue(value)) {
+      violations.push(fieldPath);
+      continue;
+    }
+
+    if (field.type === "group") {
+      violations.push(...collectNestedRequiredViolations(field.fields, value, fieldPath));
+    } else if (field.type === "array" && Array.isArray(value)) {
+      value.forEach((item, index) => {
+        violations.push(
+          ...collectNestedRequiredViolations(field.fields, item, `${fieldPath}[${index}]`),
+        );
+      });
+    }
+  }
+
+  return violations;
+};
 
 describe("RESOURCE_BLOCKS", () => {
   test("exposes exactly the six expected block slugs", () => {
@@ -117,6 +161,86 @@ describe("RESOURCE_BLOCKS", () => {
       violations.push(
         `indicator ${indicator.id} (${type}): layer_id is ${JSON.stringify(indicator.resource.layer_id)}, not the expected constant "0"`,
       );
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  test("pins which blocks require resource.name", () => {
+    // Deliberate human ruling, not an oversight: 14 real source rows (12 `feature`, 2 `imagery`)
+    // carry `resource.name: ""`. Making `name` uniformly required would make those rows
+    // unseedable in phase 2, so it's required only on `component`/`h3` — where every row
+    // populates it, and where `component`'s name is load-bearing (it keys
+    // COMPONENT_INDICATORS in containers/indicators/custom/index.tsx). Do not "normalize"
+    // this back to required on all six blocks.
+    expect(findFieldByName(blocksBySlug.get("h3")!.fields, "name")?.required).toBe(true);
+    expect(findFieldByName(blocksBySlug.get("component")!.fields, "name")?.required).toBe(true);
+
+    expect(findFieldByName(blocksBySlug.get("feature")!.fields, "name")?.required).toBeFalsy();
+    expect(findFieldByName(blocksBySlug.get("imagery")!.fields, "name")?.required).toBeFalsy();
+    expect(findFieldByName(blocksBySlug.get("imagery-tile")!.fields, "name")?.required).toBeFalsy();
+    expect(findFieldByName(blocksBySlug.get("web-tile")!.fields, "name")?.required).toBeFalsy();
+  });
+
+  test("nested required fields (legend, popupTemplate.fieldInfos) are non-empty on every row", () => {
+    const violations: string[] = [];
+
+    for (const indicator of indicators) {
+      const block = blocksBySlug.get(indicator.resource.type)!;
+
+      for (const path of collectNestedRequiredViolations(block.fields, indicator.resource)) {
+        violations.push(
+          `indicator ${indicator.id} (${indicator.resource.type}): required "${path}" is empty`,
+        );
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  test("popupTemplate.content matches the shape the schema drops and reconstructs on read", () => {
+    // The schema drops `popupTemplate.content` and rebuilds it on read as
+    // `{ title, content: [{ type: "fields", fieldInfos }] }` (see the admin description on the
+    // `popupTemplate` field in resource.ts). That reconstruction is only lossless if this shape
+    // holds for every row that carries `content` today — phase 2's transform depends on it.
+    const violations: string[] = [];
+
+    for (const indicator of indicators) {
+      const popupTemplate = (indicator.resource as { popupTemplate?: { content?: unknown } })
+        .popupTemplate;
+      const content = popupTemplate?.content;
+      if (content === undefined) continue;
+
+      if (!Array.isArray(content) || content.length !== 1) {
+        const size = Array.isArray(content) ? content.length : typeof content;
+        violations.push(
+          `indicator ${indicator.id}: popupTemplate.content has ${size} elements, expected exactly 1`,
+        );
+        continue;
+      }
+
+      const [entry] = content as Record<string, unknown>[];
+      const entryKeys = Object.keys(entry).sort().join(",");
+      if (entryKeys !== "fieldInfos,type") {
+        violations.push(
+          `indicator ${indicator.id}: popupTemplate.content[0] keys are "${entryKeys}", expected exactly "fieldInfos,type"`,
+        );
+      }
+      if (entry.type !== "fields") {
+        violations.push(
+          `indicator ${indicator.id}: popupTemplate.content[0].type is ${JSON.stringify(entry.type)}, expected "fields"`,
+        );
+      }
+
+      const fieldInfos = (entry.fieldInfos as Record<string, unknown>[] | undefined) ?? [];
+      fieldInfos.forEach((fieldInfo, index) => {
+        const fieldInfoKeys = Object.keys(fieldInfo).sort().join(",");
+        if (fieldInfoKeys !== "fieldName,label") {
+          violations.push(
+            `indicator ${indicator.id}: popupTemplate.content[0].fieldInfos[${index}] keys are "${fieldInfoKeys}", expected exactly "fieldName,label"`,
+          );
+        }
+      });
     }
 
     expect(violations).toEqual([]);

--- a/client/src/cms/fields/resource.test.ts
+++ b/client/src/cms/fields/resource.test.ts
@@ -1,0 +1,124 @@
+import type { Block } from "payload";
+
+import INDICATORS from "@/../datum/indicators.json";
+import {
+  fieldNames,
+  findFieldByName,
+  isEmptyValue,
+  namedFields,
+} from "@/cms/test-utils/find-field";
+
+import { RESOURCE_BLOCKS } from "./resource";
+
+type SourceResource = Record<string, unknown> & { type: string };
+type SourceIndicator = { id: number; resource: SourceResource };
+
+const indicators = INDICATORS as unknown as SourceIndicator[];
+
+/**
+ * Documented exceptions from the spec (§9). Any violation NOT listed here is a
+ * genuine schema bug. Remove an entry once phase 2 resolves the underlying defect.
+ */
+const KEYS_WITH_NO_HOME: Record<number, string[]> = {
+  // Indicator 12 is a `feature` but carries `rasterFunction: "Forest_Cover_Change"`,
+  // a bare string on a layer type that cannot use raster functions. Dropped on purpose.
+  12: ["rasterFunction"],
+};
+
+/**
+ * Keys present in the source JSON that deliberately have no field on the block: the value is
+ * constant across every row of that type and no code reads it. Unlike KEYS_WITH_NO_HOME these
+ * are not defects — they are fields that belong to one resource type only.
+ */
+const KEYS_DROPPED_BY_TYPE: Record<string, string[]> = {
+  // `layer_id` is the constant "0" on every imagery/h3/component row. types/indicator.ts
+  // declares it only on ResourceFeature, and all four readers in lib/indicators.ts build
+  // feature-layer URLs. Dropping it keeps the schema aligned with the TS contract.
+  imagery: ["layer_id"],
+  h3: ["layer_id"],
+  component: ["layer_id"],
+};
+
+const blocksBySlug = new Map<string, Block>(RESOURCE_BLOCKS.map((block) => [block.slug, block]));
+
+describe("RESOURCE_BLOCKS", () => {
+  test("exposes exactly the six expected block slugs", () => {
+    expect([...blocksBySlug.keys()].sort()).toEqual([
+      "component",
+      "feature",
+      "h3",
+      "imagery",
+      "imagery-tile",
+      "web-tile",
+    ]);
+  });
+
+  test("every resource.type in the source data has a matching block slug", () => {
+    const types = [...new Set(indicators.map((indicator) => indicator.resource.type))].sort();
+
+    expect(types.filter((type) => !blocksBySlug.has(type))).toEqual([]);
+  });
+
+  test("every non-empty resource key has a field in its block", () => {
+    const violations: string[] = [];
+
+    for (const indicator of indicators) {
+      const { type, ...rest } = indicator.resource;
+      const names = fieldNames(blocksBySlug.get(type)!.fields);
+
+      for (const [key, value] of Object.entries(rest)) {
+        if (isEmptyValue(value)) continue;
+        if (names.includes(key)) continue;
+        if (KEYS_WITH_NO_HOME[indicator.id]?.includes(key)) continue;
+        if (KEYS_DROPPED_BY_TYPE[type]?.includes(key)) continue;
+
+        violations.push(`indicator ${indicator.id} (${type}): "${key}" has no field`);
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  test("every required block field is non-empty on every row of that type", () => {
+    const violations: string[] = [];
+
+    for (const indicator of indicators) {
+      const block = blocksBySlug.get(indicator.resource.type)!;
+
+      for (const field of namedFields(block.fields)) {
+        if (!field.required) continue;
+        if (!isEmptyValue(indicator.resource[field.name])) continue;
+
+        violations.push(
+          `indicator ${indicator.id} (${indicator.resource.type}): required "${field.name}" is empty`,
+        );
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  test("feature blocks keep layer_id as text, since lib/indicators.ts concatenates it", () => {
+    expect(findFieldByName(blocksBySlug.get("feature")!.fields, "layer_id")?.type).toBe("text");
+  });
+
+  test("the component block keeps query_ai, which indicator 0 carries", () => {
+    expect(fieldNames(blocksBySlug.get("component")!.fields)).toContain("query_ai");
+  });
+
+  test('layer_id is always the constant "0" on every type it\'s dropped from', () => {
+    const violations: string[] = [];
+
+    for (const indicator of indicators) {
+      const { type } = indicator.resource;
+      if (!KEYS_DROPPED_BY_TYPE[type]?.includes("layer_id")) continue;
+      if (indicator.resource.layer_id === "0") continue;
+
+      violations.push(
+        `indicator ${indicator.id} (${type}): layer_id is ${JSON.stringify(indicator.resource.layer_id)}, not the expected constant "0"`,
+      );
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/client/src/cms/fields/resource.ts
+++ b/client/src/cms/fields/resource.ts
@@ -1,0 +1,172 @@
+import type { Block, Field } from "payload";
+
+/** Required on `component` and `h3`, where every row populates it. */
+const requiredNameField: Field = {
+  name: "name",
+  type: "text",
+  required: true,
+  admin: {
+    description:
+      "Machine name. Keys the COMPONENT_INDICATORS registry in containers/indicators/custom/index.tsx (`total-area`, `AMZ_LOCADM2`) — do not rename without checking that file.",
+  },
+};
+
+/**
+ * Optional on `feature`, `imagery`, `imagery-tile`, `web-tile` — empty on 14 source rows for
+ * these types, and not read by any code. Do not make this required: see requiredNameField
+ * for the block types where every row actually populates it.
+ */
+const nameField: Field = {
+  name: "name",
+  type: "text",
+  admin: {
+    description:
+      "Display/machine name. Empty on 14 source rows; not read by any code for this resource type.",
+  },
+};
+
+const urlField: Field = { name: "url", type: "text", required: true };
+
+const queryField = (name: string): Field => ({
+  name,
+  type: "json",
+  admin: {
+    description: "ArcGIS __esri.QueryProperties, passed unmodified to `new Query()`.",
+  },
+});
+
+const rasterFunctionField: Field = {
+  name: "rasterFunction",
+  type: "json",
+  required: true,
+  admin: { description: "ArcGIS __esri.RasterFunctionProperties, e.g. a Colormap function." },
+};
+
+const legendField: Field = {
+  name: "legend",
+  type: "group",
+  fields: [
+    {
+      name: "type",
+      type: "select",
+      required: true,
+      defaultValue: "basic",
+      options: [{ label: "Basic", value: "basic" }],
+    },
+    {
+      name: "items",
+      type: "array",
+      required: true,
+      minRows: 1,
+      fields: [
+        { name: "label", type: "text", required: true, localized: true },
+        {
+          name: "color",
+          type: "text",
+          required: true,
+          admin: { description: "Hex, e.g. #EEF0BA" },
+        },
+      ],
+    },
+  ],
+};
+
+export const FeatureResourceBlock: Block = {
+  slug: "feature",
+  labels: { singular: "Feature layer", plural: "Feature layers" },
+  fields: [
+    nameField,
+    urlField,
+    {
+      name: "layer_id",
+      type: "text",
+      required: true,
+      defaultValue: "0",
+      admin: {
+        description:
+          "Text, not a number: lib/indicators.ts builds the layer URL as `url + layer_id`.",
+      },
+    },
+    {
+      name: "popupTemplate",
+      type: "group",
+      fields: [
+        { name: "title", type: "text" },
+        {
+          name: "fieldInfos",
+          type: "array",
+          fields: [
+            { name: "fieldName", type: "text", required: true },
+            { name: "label", type: "text", required: true, localized: true },
+          ],
+        },
+      ],
+      admin: {
+        description:
+          "Rebuilt on read as { title, content: [{ type: 'fields', fieldInfos }] } — the only content shape present in the source data.",
+      },
+    },
+    queryField("query_numeric"),
+    queryField("query_table"),
+    queryField("query_chart"),
+    queryField("query_ai"),
+  ],
+};
+
+export const ImageryResourceBlock: Block = {
+  slug: "imagery",
+  labels: { singular: "Imagery layer", plural: "Imagery layers" },
+  fields: [nameField, urlField, rasterFunctionField, legendField],
+};
+
+export const ImageryTileResourceBlock: Block = {
+  slug: "imagery-tile",
+  labels: { singular: "Imagery tile layer", plural: "Imagery tile layers" },
+  fields: [nameField, urlField, rasterFunctionField, legendField],
+};
+
+export const WebTileResourceBlock: Block = {
+  slug: "web-tile",
+  labels: { singular: "Web tile layer", plural: "Web tile layers" },
+  fields: [nameField, urlField],
+};
+
+export const H3ResourceBlock: Block = {
+  slug: "h3",
+  labels: { singular: "H3 grid column", plural: "H3 grid columns" },
+  fields: [
+    requiredNameField,
+    {
+      name: "column",
+      type: "text",
+      required: true,
+      admin: { description: "H3 variable name, matched against META.datasets[].var_name." },
+    },
+    { name: "url", type: "text" },
+  ],
+};
+
+export const ComponentResourceBlock: Block = {
+  slug: "component",
+  labels: { singular: "Custom component", plural: "Custom components" },
+  fields: [requiredNameField, queryField("query_ai")],
+};
+
+export const RESOURCE_BLOCKS: Block[] = [
+  FeatureResourceBlock,
+  ImageryResourceBlock,
+  ImageryTileResourceBlock,
+  WebTileResourceBlock,
+  H3ResourceBlock,
+  ComponentResourceBlock,
+];
+
+export const ResourceField: Field = {
+  name: "resource",
+  type: "blocks",
+  required: true,
+  minRows: 1,
+  maxRows: 1,
+  blocks: RESOURCE_BLOCKS,
+  admin: { description: "Exactly one resource. The block type is the resource type." },
+};

--- a/client/src/cms/hooks/indicator-visualization.test.ts
+++ b/client/src/cms/hooks/indicator-visualization.test.ts
@@ -1,0 +1,95 @@
+import INDICATORS from "@/../datum/indicators.json";
+
+import { findVisualizationMismatches } from "./indicator-visualization";
+
+const featureResource = (overrides: Record<string, unknown> = {}) => ({
+  blockType: "feature",
+  name: "test-layer",
+  url: "https://example.test/FeatureServer/",
+  layer_id: "0",
+  ...overrides,
+});
+
+describe("findVisualizationMismatches", () => {
+  test("returns nothing when a declared type has a matching query", () => {
+    expect(
+      findVisualizationMismatches({
+        visualization_types: ["numeric"],
+        resource: featureResource({ query_numeric: { where: "1=1" } }),
+      }),
+    ).toEqual([]);
+  });
+
+  test("flags a declared type with no matching query", () => {
+    expect(
+      findVisualizationMismatches({
+        visualization_types: ["table"],
+        resource: featureResource(),
+      }),
+    ).toEqual([{ kind: "declared-without-query", type: "table" }]);
+  });
+
+  test("flags a query whose type is not declared", () => {
+    expect(
+      findVisualizationMismatches({
+        visualization_types: ["numeric"],
+        resource: featureResource({
+          query_numeric: { where: "1=1" },
+          query_chart: { where: "1=1" },
+        }),
+      }),
+    ).toEqual([{ kind: "query-without-declared", type: "chart" }]);
+  });
+
+  test("ignores `map`, which has no corresponding query field", () => {
+    expect(
+      findVisualizationMismatches({
+        visualization_types: ["map"],
+        resource: featureResource(),
+      }),
+    ).toEqual([]);
+  });
+
+  test("ignores imagery: its numerics come from histograms, not a query", () => {
+    expect(
+      findVisualizationMismatches({
+        visualization_types: ["map", "numeric"],
+        resource: { blockType: "imagery", name: "slope", url: "https://example.test/ImageServer" },
+      }),
+    ).toEqual([]);
+  });
+
+  test("ignores h3 rows, which declare no visualization types", () => {
+    expect(
+      findVisualizationMismatches({
+        visualization_types: [],
+        resource: { blockType: "h3", name: "altitude", column: "ALTMEAN" },
+      }),
+    ).toEqual([]);
+  });
+
+  test("tolerates missing and malformed input without throwing", () => {
+    expect(findVisualizationMismatches({})).toEqual([]);
+    expect(findVisualizationMismatches({ visualization_types: null, resource: null })).toEqual([]);
+    expect(findVisualizationMismatches({ visualization_types: "map", resource: 42 })).toEqual([]);
+  });
+});
+
+describe("findVisualizationMismatches against the real source data", () => {
+  test("flags exactly one row across all 164 indicators: indicator 5", () => {
+    const flagged = (INDICATORS as unknown as { id: number; visualization_types: string[]; resource: Record<string, unknown> }[])
+      .map((indicator) => ({
+        id: indicator.id,
+        mismatches: findVisualizationMismatches({
+          visualization_types: indicator.visualization_types,
+          // The source JSON uses `type`; Payload blocks use `blockType`.
+          resource: { ...indicator.resource, blockType: indicator.resource.type },
+        }),
+      }))
+      .filter(({ mismatches }) => mismatches.length > 0);
+
+    expect(flagged).toEqual([
+      { id: 5, mismatches: [{ kind: "query-without-declared", type: "chart" }] },
+    ]);
+  });
+});

--- a/client/src/cms/hooks/indicator-visualization.test.ts
+++ b/client/src/cms/hooks/indicator-visualization.test.ts
@@ -1,6 +1,7 @@
+import { describe, expect, test, vi } from "vitest";
 import INDICATORS from "@/../datum/indicators.json";
 
-import { findVisualizationMismatches } from "./indicator-visualization";
+import { findVisualizationMismatches, warnOnVisualizationMismatch } from "./indicator-visualization";
 
 const featureResource = (overrides: Record<string, unknown> = {}) => ({
   blockType: "feature",
@@ -77,7 +78,13 @@ describe("findVisualizationMismatches", () => {
 
 describe("findVisualizationMismatches against the real source data", () => {
   test("flags exactly one row across all 164 indicators: indicator 5", () => {
-    const flagged = (INDICATORS as unknown as { id: number; visualization_types: string[]; resource: Record<string, unknown> }[])
+    const flagged = (
+      INDICATORS as unknown as {
+        id: number;
+        visualization_types: string[];
+        resource: Record<string, unknown>;
+      }[]
+    )
       .map((indicator) => ({
         id: indicator.id,
         mismatches: findVisualizationMismatches({
@@ -91,5 +98,152 @@ describe("findVisualizationMismatches against the real source data", () => {
     expect(flagged).toEqual([
       { id: 5, mismatches: [{ kind: "query-without-declared", type: "chart" }] },
     ]);
+  });
+});
+
+describe("warnOnVisualizationMismatch", () => {
+  test("logs a warning for a mismatch on Payload-shaped input (resource as array)", () => {
+    const warn = vi.fn();
+    const req = { payload: { logger: { warn } } } as never;
+    const data = {
+      visualization_types: ["map"],
+      resource: [
+        {
+          blockType: "feature",
+          name: "test-layer",
+          url: "https://example.test/FeatureServer/",
+          query_chart: { where: "1=1" },
+        },
+      ],
+      legacy_id: 42,
+    };
+
+    const result = warnOnVisualizationMismatch({ req, data } as never);
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      'Indicator 42 has a query_chart but does not declare "chart". The widget may render empty.',
+    );
+    expect(result).toEqual(data);
+  });
+
+  test("handles non-array resource (bare object)", () => {
+    const warn = vi.fn();
+    const req = { payload: { logger: { warn } } } as never;
+    const data = {
+      visualization_types: ["table"],
+      resource: {
+        blockType: "feature",
+        name: "test-layer",
+        url: "https://example.test/FeatureServer/",
+      },
+      legacy_id: 5,
+    };
+
+    const result = warnOnVisualizationMismatch({ req, data } as never);
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      'Indicator 5 declares "table" but has no query_table. The widget may render empty.',
+    );
+    expect(result).toEqual(data);
+  });
+
+  test("does not log a warning when there are no mismatches", () => {
+    const warn = vi.fn();
+    const req = { payload: { logger: { warn } } } as never;
+    const data = {
+      visualization_types: ["numeric"],
+      resource: {
+        blockType: "feature",
+        name: "test-layer",
+        url: "https://example.test/FeatureServer/",
+        query_numeric: { where: "1=1" },
+      },
+      legacy_id: 10,
+    };
+
+    const result = warnOnVisualizationMismatch({ req, data } as never);
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(result).toEqual(data);
+  });
+
+  test("returns data unchanged on the non-warning path", () => {
+    const warn = vi.fn();
+    const req = { payload: { logger: { warn } } } as never;
+    const data = {
+      visualization_types: ["map"],
+      resource: { blockType: "imagery", name: "slope" },
+    };
+
+    const result = warnOnVisualizationMismatch({ req, data } as never);
+
+    expect(result).toBe(data);
+  });
+
+  test("uses legacy_id fallback when legacy_id is absent", () => {
+    const warn = vi.fn();
+    const req = { payload: { logger: { warn } } } as never;
+    const data = {
+      visualization_types: ["chart"],
+      resource: {
+        blockType: "feature",
+        name: "test-layer",
+        url: "https://example.test/FeatureServer/",
+      },
+    };
+
+    warnOnVisualizationMismatch({ req, data } as never);
+
+    expect(warn).toHaveBeenCalledWith(
+      'Indicator (new) declares "chart" but has no query_chart. The widget may render empty.',
+    );
+  });
+
+  test("logs multiple warnings for multiple mismatches", () => {
+    const warn = vi.fn();
+    const req = { payload: { logger: { warn } } } as never;
+    const data = {
+      visualization_types: ["numeric", "table"],
+      resource: [
+        {
+          blockType: "feature",
+          name: "test-layer",
+          url: "https://example.test/FeatureServer/",
+        },
+      ],
+      legacy_id: 99,
+    };
+
+    warnOnVisualizationMismatch({ req, data } as never);
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenNthCalledWith(
+      1,
+      'Indicator 99 declares "numeric" but has no query_numeric. The widget may render empty.',
+    );
+    expect(warn).toHaveBeenNthCalledWith(
+      2,
+      'Indicator 99 declares "table" but has no query_table. The widget may render empty.',
+    );
+  });
+
+  test("returns data unchanged when warnings are logged", () => {
+    const warn = vi.fn();
+    const req = { payload: { logger: { warn } } } as never;
+    const data = {
+      visualization_types: ["table"],
+      resource: {
+        blockType: "feature",
+        name: "test-layer",
+        url: "https://example.test/FeatureServer/",
+      },
+      legacy_id: 7,
+    };
+
+    const result = warnOnVisualizationMismatch({ req, data } as never);
+
+    expect(result).toBe(data);
   });
 });

--- a/client/src/cms/hooks/indicator-visualization.test.ts
+++ b/client/src/cms/hooks/indicator-visualization.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test, vi } from "vitest";
+
 import INDICATORS from "@/../datum/indicators.json";
 
-import { findVisualizationMismatches, warnOnVisualizationMismatch } from "./indicator-visualization";
+import {
+  findVisualizationMismatches,
+  warnOnVisualizationMismatch,
+} from "./indicator-visualization";
 
 const featureResource = (overrides: Record<string, unknown> = {}) => ({
   blockType: "feature",

--- a/client/src/cms/hooks/indicator-visualization.ts
+++ b/client/src/cms/hooks/indicator-visualization.ts
@@ -13,7 +13,8 @@ export type VisualizationMismatch = {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const isPresentQuery = (value: unknown): boolean => isRecord(value) && Object.keys(value).length > 0;
+const isPresentQuery = (value: unknown): boolean =>
+  isRecord(value) && Object.keys(value).length > 0;
 
 /**
  * Reports disagreements between an indicator's declared `visualization_types` and the

--- a/client/src/cms/hooks/indicator-visualization.ts
+++ b/client/src/cms/hooks/indicator-visualization.ts
@@ -1,0 +1,75 @@
+import type { CollectionBeforeChangeHook } from "payload";
+
+/** Visualization types that have a corresponding `query_*` field on a feature resource. */
+const QUERYABLE_TYPES = ["numeric", "table", "chart"] as const;
+
+export type QueryableVisualizationType = (typeof QUERYABLE_TYPES)[number];
+
+export type VisualizationMismatch = {
+  kind: "declared-without-query" | "query-without-declared";
+  type: QueryableVisualizationType;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isPresentQuery = (value: unknown): boolean => isRecord(value) && Object.keys(value).length > 0;
+
+/**
+ * Reports disagreements between an indicator's declared `visualization_types` and the
+ * `query_*` objects on its resource.
+ *
+ * Scoped to `feature` resources on purpose:
+ * - `map` has no `query_map`, so it can never be cross-checked.
+ * - `imagery` numerics come from `computeStatisticsHistograms`, not a query, so 17 valid
+ *   rows declare `numeric` with no `query_numeric`. Flagging those would be pure noise.
+ * - `h3` and `component` declare nothing queryable.
+ */
+export const findVisualizationMismatches = (input: {
+  visualization_types?: unknown;
+  resource?: unknown;
+}): VisualizationMismatch[] => {
+  const resource = isRecord(input.resource) ? input.resource : null;
+
+  if (resource?.blockType !== "feature") return [];
+
+  const declared = new Set(
+    Array.isArray(input.visualization_types) ? input.visualization_types : [],
+  );
+
+  return QUERYABLE_TYPES.flatMap<VisualizationMismatch>((type) => {
+    const hasQuery = isPresentQuery(resource[`query_${type}`]);
+    const isDeclared = declared.has(type);
+
+    if (isDeclared && !hasQuery) return [{ kind: "declared-without-query", type }];
+    if (hasQuery && !isDeclared) return [{ kind: "query-without-declared", type }];
+
+    return [];
+  });
+};
+
+/**
+ * Non-blocking: logs a warning and always returns `data` unchanged.
+ *
+ * Must not be a `validate` function — that can only pass or fail, and failing would stop
+ * phase-2 seeding of indicator 5, which legitimately carries this inconsistency today.
+ */
+export const warnOnVisualizationMismatch: CollectionBeforeChangeHook = ({ req, data }) => {
+  const resource = Array.isArray(data?.resource) ? data.resource[0] : data?.resource;
+
+  for (const mismatch of findVisualizationMismatches({
+    visualization_types: data?.visualization_types,
+    resource,
+  })) {
+    const detail =
+      mismatch.kind === "declared-without-query"
+        ? `declares "${mismatch.type}" but has no query_${mismatch.type}`
+        : `has a query_${mismatch.type} but does not declare "${mismatch.type}"`;
+
+    req.payload.logger.warn(
+      `Indicator ${data?.legacy_id ?? "(new)"} ${detail}. The widget may render empty.`,
+    );
+  }
+
+  return data;
+};

--- a/client/src/cms/migrations/20260803_090559.json
+++ b/client/src/cms/migrations/20260803_090559.json
@@ -1,0 +1,8942 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins_sessions": {
+      "name": "admins_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "admins_sessions_order_idx": {
+          "name": "admins_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admins_sessions_parent_id_idx": {
+          "name": "admins_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admins_sessions_parent_id_fk": {
+          "name": "admins_sessions_parent_id_fk",
+          "tableFrom": "admins_sessions",
+          "tableTo": "admins",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admins_updated_at_idx": {
+          "name": "admins_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admins_created_at_idx": {
+          "name": "admins_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admins_email_idx": {
+          "name": "admins_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users_sessions": {
+      "name": "users_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_verified": {
+          "name": "_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_verificationtoken": {
+          "name": "_verificationtoken",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anonymous_users": {
+      "name": "anonymous_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "anonymous_users_updated_at_idx": {
+          "name": "anonymous_users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "anonymous_users_created_at_idx": {
+          "name": "anonymous_users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_idx": {
+          "name": "accounts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_updated_at_idx": {
+          "name": "accounts_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_created_at_idx": {
+          "name": "accounts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_providerAccountId_idx": {
+          "name": "provider_providerAccountId_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alt": {
+          "name": "alt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_updated_at_idx": {
+          "name": "media_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_created_at_idx": {
+          "name": "media_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_filename_idx": {
+          "name": "media_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports_topics_indicators": {
+      "name": "reports_topics_indicators",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "indicator_id": {
+          "name": "indicator_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum_reports_topics_indicators_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "w": {
+          "name": "w",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "h": {
+          "name": "h",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basemap_id": {
+          "name": "basemap_id",
+          "type": "enum_reports_topics_indicators_basemap_id",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'gray-vector'"
+        },
+        "opacity": {
+          "name": "opacity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "reports_topics_indicators_order_idx": {
+          "name": "reports_topics_indicators_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_topics_indicators_parent_id_idx": {
+          "name": "reports_topics_indicators_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reports_topics_indicators_parent_id_fk": {
+          "name": "reports_topics_indicators_parent_id_fk",
+          "tableFrom": "reports_topics_indicators",
+          "tableTo": "reports_topics",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports_topics": {
+      "name": "reports_topics",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reports_topics_order_idx": {
+          "name": "reports_topics_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_topics_parent_id_idx": {
+          "name": "reports_topics_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reports_topics_parent_id_fk": {
+          "name": "reports_topics_parent_id_fk",
+          "tableFrom": "reports_topics",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports_topics_locales": {
+      "name": "reports_topics_locales",
+      "schema": "",
+      "columns": {
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "reports_topics_locales_locale_parent_id_unique": {
+          "name": "reports_topics_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reports_topics_locales_parent_id_fk": {
+          "name": "reports_topics_locales_parent_id_fk",
+          "tableFrom": "reports_topics_locales",
+          "tableTo": "reports_topics",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "location": {
+          "name": "location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_reports_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "reports_updated_at_idx": {
+          "name": "reports_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_created_at_idx": {
+          "name": "reports_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports__status_idx": {
+          "name": "reports__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports_locales": {
+      "name": "reports_locales",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "reports_locales_locale_parent_id_unique": {
+          "name": "reports_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reports_locales_parent_id_fk": {
+          "name": "reports_locales_parent_id_fk",
+          "tableFrom": "reports_locales",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports_rels": {
+      "name": "reports_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_users_id": {
+          "name": "anonymous_users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reports_rels_order_idx": {
+          "name": "reports_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_rels_parent_idx": {
+          "name": "reports_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_rels_path_idx": {
+          "name": "reports_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_rels_users_id_idx": {
+          "name": "reports_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reports_rels_anonymous_users_id_idx": {
+          "name": "reports_rels_anonymous_users_id_idx",
+          "columns": [
+            {
+              "expression": "anonymous_users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reports_rels_parent_fk": {
+          "name": "reports_rels_parent_fk",
+          "tableFrom": "reports_rels",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reports_rels_users_fk": {
+          "name": "reports_rels_users_fk",
+          "tableFrom": "reports_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reports_rels_anonymous_users_fk": {
+          "name": "reports_rels_anonymous_users_fk",
+          "tableFrom": "reports_rels",
+          "tableTo": "anonymous_users",
+          "columnsFrom": [
+            "anonymous_users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._reports_v_version_topics_indicators": {
+      "name": "_reports_v_version_topics_indicators",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "indicator_id": {
+          "name": "indicator_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum__reports_v_version_topics_indicators_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "w": {
+          "name": "w",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "h": {
+          "name": "h",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basemap_id": {
+          "name": "basemap_id",
+          "type": "enum__reports_v_version_topics_indicators_basemap_id",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'gray-vector'"
+        },
+        "opacity": {
+          "name": "opacity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_reports_v_version_topics_indicators_order_idx": {
+          "name": "_reports_v_version_topics_indicators_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_reports_v_version_topics_indicators_parent_id_idx": {
+          "name": "_reports_v_version_topics_indicators_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_reports_v_version_topics_indicators_parent_id_fk": {
+          "name": "_reports_v_version_topics_indicators_parent_id_fk",
+          "tableFrom": "_reports_v_version_topics_indicators",
+          "tableTo": "_reports_v_version_topics",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._reports_v_version_topics": {
+      "name": "_reports_v_version_topics",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_reports_v_version_topics_order_idx": {
+          "name": "_reports_v_version_topics_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_reports_v_version_topics_parent_id_idx": {
+          "name": "_reports_v_version_topics_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_reports_v_version_topics_parent_id_fk": {
+          "name": "_reports_v_version_topics_parent_id_fk",
+          "tableFrom": "_reports_v_version_topics",
+          "tableTo": "_reports_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._reports_v_version_topics_locales": {
+      "name": "_reports_v_version_topics_locales",
+      "schema": "",
+      "columns": {
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_reports_v_version_topics_locales_locale_parent_id_unique": {
+          "name": "_reports_v_version_topics_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_reports_v_version_topics_locales_parent_id_fk": {
+          "name": "_reports_v_version_topics_locales_parent_id_fk",
+          "tableFrom": "_reports_v_version_topics_locales",
+          "tableTo": "_reports_v_version_topics",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._reports_v": {
+      "name": "_reports_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_location": {
+          "name": "version_location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__reports_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_locale": {
+          "name": "published_locale",
+          "type": "enum__reports_v_published_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_reports_v_parent_idx": {
+          "name": "_reports_v_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_reports_v_version_version_updated_at_idx": {
+          "name": "_reports_v_version_version_updated_at_idx",
+          "columns": [
+            {
+              "expression": "version_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_reports_v_version_version_created_at_idx": {
+          "name": "_reports_v_version_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "version_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_reports_v_version_version__status_idx": {
+          "name": "_reports_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_reports_v_created_at_idx": {
+          "name": "_reports_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_reports_v_updated_at_idx": {
+          "name": "_reports_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_reports_v_snapshot_idx": {
+          "name": "_reports_v_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_reports_v_published_locale_idx": {
+          "name": "_reports_v_published_locale_idx",
+          "columns": [
+            {
+              "expression": "published_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_reports_v_latest_idx": {
+          "name": "_reports_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_reports_v_parent_id_reports_id_fk": {
+          "name": "_reports_v_parent_id_reports_id_fk",
+          "tableFrom": "_reports_v",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._reports_v_locales": {
+      "name": "_reports_v_locales",
+      "schema": "",
+      "columns": {
+        "version_title": {
+          "name": "version_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_description": {
+          "name": "version_description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_reports_v_locales_locale_parent_id_unique": {
+          "name": "_reports_v_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_reports_v_locales_parent_id_fk": {
+          "name": "_reports_v_locales_parent_id_fk",
+          "tableFrom": "_reports_v_locales",
+          "tableTo": "_reports_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._reports_v_rels": {
+      "name": "_reports_v_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_users_id": {
+          "name": "anonymous_users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_reports_v_rels_order_idx": {
+          "name": "_reports_v_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_reports_v_rels_parent_idx": {
+          "name": "_reports_v_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_reports_v_rels_path_idx": {
+          "name": "_reports_v_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_reports_v_rels_users_id_idx": {
+          "name": "_reports_v_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_reports_v_rels_anonymous_users_id_idx": {
+          "name": "_reports_v_rels_anonymous_users_id_idx",
+          "columns": [
+            {
+              "expression": "anonymous_users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_reports_v_rels_parent_fk": {
+          "name": "_reports_v_rels_parent_fk",
+          "tableFrom": "_reports_v_rels",
+          "tableTo": "_reports_v",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_reports_v_rels_users_fk": {
+          "name": "_reports_v_rels_users_fk",
+          "tableFrom": "_reports_v_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_reports_v_rels_anonymous_users_fk": {
+          "name": "_reports_v_rels_anonymous_users_fk",
+          "tableFrom": "_reports_v_rels",
+          "tableTo": "anonymous_users",
+          "columnsFrom": [
+            "anonymous_users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics_default_visualization": {
+      "name": "topics_default_visualization",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "indicator_id": {
+          "name": "indicator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum_topics_default_visualization_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "w": {
+          "name": "w",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "h": {
+          "name": "h",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basemap_id": {
+          "name": "basemap_id",
+          "type": "enum_topics_default_visualization_basemap_id",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'gray-vector'"
+        },
+        "opacity": {
+          "name": "opacity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "topics_default_visualization_order_idx": {
+          "name": "topics_default_visualization_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_default_visualization_parent_id_idx": {
+          "name": "topics_default_visualization_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_default_visualization_indicator_idx": {
+          "name": "topics_default_visualization_indicator_idx",
+          "columns": [
+            {
+              "expression": "indicator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_default_visualization_indicator_id_indicators_id_fk": {
+          "name": "topics_default_visualization_indicator_id_indicators_id_fk",
+          "tableFrom": "topics_default_visualization",
+          "tableTo": "indicators",
+          "columnsFrom": [
+            "indicator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "topics_default_visualization_parent_id_fk": {
+          "name": "topics_default_visualization_parent_id_fk",
+          "tableFrom": "topics_default_visualization",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_topics_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "topics_legacy_id_idx": {
+          "name": "topics_legacy_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_updated_at_idx": {
+          "name": "topics_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_created_at_idx": {
+          "name": "topics_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics__status_idx": {
+          "name": "topics__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics_locales": {
+      "name": "topics_locales",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "topics_locales_locale_parent_id_unique": {
+          "name": "topics_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_locales_parent_id_fk": {
+          "name": "topics_locales_parent_id_fk",
+          "tableFrom": "topics_locales",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._topics_v_version_default_visualization": {
+      "name": "_topics_v_version_default_visualization",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "indicator_id": {
+          "name": "indicator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum__topics_v_version_default_visualization_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "w": {
+          "name": "w",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "h": {
+          "name": "h",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basemap_id": {
+          "name": "basemap_id",
+          "type": "enum__topics_v_version_default_visualization_basemap_id",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'gray-vector'"
+        },
+        "opacity": {
+          "name": "opacity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_topics_v_version_default_visualization_order_idx": {
+          "name": "_topics_v_version_default_visualization_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_topics_v_version_default_visualization_parent_id_idx": {
+          "name": "_topics_v_version_default_visualization_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_topics_v_version_default_visualization_indicator_idx": {
+          "name": "_topics_v_version_default_visualization_indicator_idx",
+          "columns": [
+            {
+              "expression": "indicator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_topics_v_version_default_visualization_indicator_id_indicators_id_fk": {
+          "name": "_topics_v_version_default_visualization_indicator_id_indicators_id_fk",
+          "tableFrom": "_topics_v_version_default_visualization",
+          "tableTo": "indicators",
+          "columnsFrom": [
+            "indicator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_topics_v_version_default_visualization_parent_id_fk": {
+          "name": "_topics_v_version_default_visualization_parent_id_fk",
+          "tableFrom": "_topics_v_version_default_visualization",
+          "tableTo": "_topics_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._topics_v": {
+      "name": "_topics_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_legacy_id": {
+          "name": "version_legacy_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_image": {
+          "name": "version_image",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__topics_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_locale": {
+          "name": "published_locale",
+          "type": "enum__topics_v_published_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_topics_v_parent_idx": {
+          "name": "_topics_v_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_topics_v_version_version_legacy_id_idx": {
+          "name": "_topics_v_version_version_legacy_id_idx",
+          "columns": [
+            {
+              "expression": "version_legacy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_topics_v_version_version_updated_at_idx": {
+          "name": "_topics_v_version_version_updated_at_idx",
+          "columns": [
+            {
+              "expression": "version_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_topics_v_version_version_created_at_idx": {
+          "name": "_topics_v_version_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "version_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_topics_v_version_version__status_idx": {
+          "name": "_topics_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_topics_v_created_at_idx": {
+          "name": "_topics_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_topics_v_updated_at_idx": {
+          "name": "_topics_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_topics_v_snapshot_idx": {
+          "name": "_topics_v_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_topics_v_published_locale_idx": {
+          "name": "_topics_v_published_locale_idx",
+          "columns": [
+            {
+              "expression": "published_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_topics_v_latest_idx": {
+          "name": "_topics_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_topics_v_parent_id_topics_id_fk": {
+          "name": "_topics_v_parent_id_topics_id_fk",
+          "tableFrom": "_topics_v",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._topics_v_locales": {
+      "name": "_topics_v_locales",
+      "schema": "",
+      "columns": {
+        "version_name": {
+          "name": "version_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_description": {
+          "name": "version_description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_topics_v_locales_locale_parent_id_unique": {
+          "name": "_topics_v_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_topics_v_locales_parent_id_fk": {
+          "name": "_topics_v_locales_parent_id_fk",
+          "tableFrom": "_topics_v_locales",
+          "tableTo": "_topics_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subtopics_default_visualization": {
+      "name": "subtopics_default_visualization",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "indicator_id": {
+          "name": "indicator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum_subtopics_default_visualization_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "w": {
+          "name": "w",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "h": {
+          "name": "h",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basemap_id": {
+          "name": "basemap_id",
+          "type": "enum_subtopics_default_visualization_basemap_id",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'gray-vector'"
+        },
+        "opacity": {
+          "name": "opacity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "subtopics_default_visualization_order_idx": {
+          "name": "subtopics_default_visualization_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subtopics_default_visualization_parent_id_idx": {
+          "name": "subtopics_default_visualization_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subtopics_default_visualization_indicator_idx": {
+          "name": "subtopics_default_visualization_indicator_idx",
+          "columns": [
+            {
+              "expression": "indicator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subtopics_default_visualization_indicator_id_indicators_id_fk": {
+          "name": "subtopics_default_visualization_indicator_id_indicators_id_fk",
+          "tableFrom": "subtopics_default_visualization",
+          "tableTo": "indicators",
+          "columnsFrom": [
+            "indicator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "subtopics_default_visualization_parent_id_fk": {
+          "name": "subtopics_default_visualization_parent_id_fk",
+          "tableFrom": "subtopics_default_visualization",
+          "tableTo": "subtopics",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subtopics": {
+      "name": "subtopics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_subtopics_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "subtopics_legacy_id_idx": {
+          "name": "subtopics_legacy_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subtopics_topic_idx": {
+          "name": "subtopics_topic_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subtopics_updated_at_idx": {
+          "name": "subtopics_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subtopics_created_at_idx": {
+          "name": "subtopics_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subtopics__status_idx": {
+          "name": "subtopics__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subtopics_topic_id_topics_id_fk": {
+          "name": "subtopics_topic_id_topics_id_fk",
+          "tableFrom": "subtopics",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subtopics_locales": {
+      "name": "subtopics_locales",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "subtopics_locales_locale_parent_id_unique": {
+          "name": "subtopics_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subtopics_locales_parent_id_fk": {
+          "name": "subtopics_locales_parent_id_fk",
+          "tableFrom": "subtopics_locales",
+          "tableTo": "subtopics",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._subtopics_v_version_default_visualization": {
+      "name": "_subtopics_v_version_default_visualization",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "indicator_id": {
+          "name": "indicator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum__subtopics_v_version_default_visualization_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "w": {
+          "name": "w",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "h": {
+          "name": "h",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basemap_id": {
+          "name": "basemap_id",
+          "type": "enum__subtopics_v_version_default_visualization_basemap_id",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'gray-vector'"
+        },
+        "opacity": {
+          "name": "opacity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_subtopics_v_version_default_visualization_order_idx": {
+          "name": "_subtopics_v_version_default_visualization_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_subtopics_v_version_default_visualization_parent_id_idx": {
+          "name": "_subtopics_v_version_default_visualization_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_subtopics_v_version_default_visualization_indicator_idx": {
+          "name": "_subtopics_v_version_default_visualization_indicator_idx",
+          "columns": [
+            {
+              "expression": "indicator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_subtopics_v_version_default_visualization_indicator_id_indicators_id_fk": {
+          "name": "_subtopics_v_version_default_visualization_indicator_id_indicators_id_fk",
+          "tableFrom": "_subtopics_v_version_default_visualization",
+          "tableTo": "indicators",
+          "columnsFrom": [
+            "indicator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_subtopics_v_version_default_visualization_parent_id_fk": {
+          "name": "_subtopics_v_version_default_visualization_parent_id_fk",
+          "tableFrom": "_subtopics_v_version_default_visualization",
+          "tableTo": "_subtopics_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._subtopics_v": {
+      "name": "_subtopics_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_legacy_id": {
+          "name": "version_legacy_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_topic_id": {
+          "name": "version_topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__subtopics_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_locale": {
+          "name": "published_locale",
+          "type": "enum__subtopics_v_published_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_subtopics_v_parent_idx": {
+          "name": "_subtopics_v_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_subtopics_v_version_version_legacy_id_idx": {
+          "name": "_subtopics_v_version_version_legacy_id_idx",
+          "columns": [
+            {
+              "expression": "version_legacy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_subtopics_v_version_version_topic_idx": {
+          "name": "_subtopics_v_version_version_topic_idx",
+          "columns": [
+            {
+              "expression": "version_topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_subtopics_v_version_version_updated_at_idx": {
+          "name": "_subtopics_v_version_version_updated_at_idx",
+          "columns": [
+            {
+              "expression": "version_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_subtopics_v_version_version_created_at_idx": {
+          "name": "_subtopics_v_version_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "version_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_subtopics_v_version_version__status_idx": {
+          "name": "_subtopics_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_subtopics_v_created_at_idx": {
+          "name": "_subtopics_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_subtopics_v_updated_at_idx": {
+          "name": "_subtopics_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_subtopics_v_snapshot_idx": {
+          "name": "_subtopics_v_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_subtopics_v_published_locale_idx": {
+          "name": "_subtopics_v_published_locale_idx",
+          "columns": [
+            {
+              "expression": "published_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_subtopics_v_latest_idx": {
+          "name": "_subtopics_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_subtopics_v_parent_id_subtopics_id_fk": {
+          "name": "_subtopics_v_parent_id_subtopics_id_fk",
+          "tableFrom": "_subtopics_v",
+          "tableTo": "subtopics",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_subtopics_v_version_topic_id_topics_id_fk": {
+          "name": "_subtopics_v_version_topic_id_topics_id_fk",
+          "tableFrom": "_subtopics_v",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "version_topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._subtopics_v_locales": {
+      "name": "_subtopics_v_locales",
+      "schema": "",
+      "columns": {
+        "version_name": {
+          "name": "version_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_description": {
+          "name": "version_description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_subtopics_v_locales_locale_parent_id_unique": {
+          "name": "_subtopics_v_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_subtopics_v_locales_parent_id_fk": {
+          "name": "_subtopics_v_locales_parent_id_fk",
+          "tableFrom": "_subtopics_v_locales",
+          "tableTo": "_subtopics_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicators_visualization_types": {
+      "name": "indicators_visualization_types",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum_indicators_visualization_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        }
+      },
+      "indexes": {
+        "indicators_visualization_types_order_idx": {
+          "name": "indicators_visualization_types_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_visualization_types_parent_idx": {
+          "name": "indicators_visualization_types_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "indicators_visualization_types_parent_fk": {
+          "name": "indicators_visualization_types_parent_fk",
+          "tableFrom": "indicators_visualization_types",
+          "tableTo": "indicators",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicators_blocks_feature_popup_template_field_infos": {
+      "name": "indicators_blocks_feature_popup_template_field_infos",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indicators_blocks_feature_popup_template_field_infos_order_idx": {
+          "name": "indicators_blocks_feature_popup_template_field_infos_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_blocks_feature_popup_template_field_infos_parent_id_idx": {
+          "name": "indicators_blocks_feature_popup_template_field_infos_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "indicators_blocks_feature_popup_template_field_infos_parent_id_fk": {
+          "name": "indicators_blocks_feature_popup_template_field_infos_parent_id_fk",
+          "tableFrom": "indicators_blocks_feature_popup_template_field_infos",
+          "tableTo": "indicators_blocks_feature",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicators_blocks_feature_popup_template_field_infos_locales": {
+      "name": "indicators_blocks_feature_popup_template_field_infos_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "indicators_blocks_feature_popup_template_field_infos_local_1": {
+          "name": "indicators_blocks_feature_popup_template_field_infos_local_1",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "indicators_blocks_feature_popup_template_field_infos_loca_fk": {
+          "name": "indicators_blocks_feature_popup_template_field_infos_loca_fk",
+          "tableFrom": "indicators_blocks_feature_popup_template_field_infos_locales",
+          "tableTo": "indicators_blocks_feature_popup_template_field_infos",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicators_blocks_feature": {
+      "name": "indicators_blocks_feature",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layer_id": {
+          "name": "layer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "popup_template_title": {
+          "name": "popup_template_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_numeric": {
+          "name": "query_numeric",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_table": {
+          "name": "query_table",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_chart": {
+          "name": "query_chart",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_ai": {
+          "name": "query_ai",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indicators_blocks_feature_order_idx": {
+          "name": "indicators_blocks_feature_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_blocks_feature_parent_id_idx": {
+          "name": "indicators_blocks_feature_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_blocks_feature_path_idx": {
+          "name": "indicators_blocks_feature_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "indicators_blocks_feature_parent_id_fk": {
+          "name": "indicators_blocks_feature_parent_id_fk",
+          "tableFrom": "indicators_blocks_feature",
+          "tableTo": "indicators",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicators_blocks_imagery_legend_items": {
+      "name": "indicators_blocks_imagery_legend_items",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indicators_blocks_imagery_legend_items_order_idx": {
+          "name": "indicators_blocks_imagery_legend_items_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_blocks_imagery_legend_items_parent_id_idx": {
+          "name": "indicators_blocks_imagery_legend_items_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "indicators_blocks_imagery_legend_items_parent_id_fk": {
+          "name": "indicators_blocks_imagery_legend_items_parent_id_fk",
+          "tableFrom": "indicators_blocks_imagery_legend_items",
+          "tableTo": "indicators_blocks_imagery",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicators_blocks_imagery_legend_items_locales": {
+      "name": "indicators_blocks_imagery_legend_items_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "indicators_blocks_imagery_legend_items_locales_locale_parent": {
+          "name": "indicators_blocks_imagery_legend_items_locales_locale_parent",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "indicators_blocks_imagery_legend_items_locales_parent_id_fk": {
+          "name": "indicators_blocks_imagery_legend_items_locales_parent_id_fk",
+          "tableFrom": "indicators_blocks_imagery_legend_items_locales",
+          "tableTo": "indicators_blocks_imagery_legend_items",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicators_blocks_imagery": {
+      "name": "indicators_blocks_imagery",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raster_function": {
+          "name": "raster_function",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legend_type": {
+          "name": "legend_type",
+          "type": "enum_indicators_blocks_imagery_legend_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'basic'"
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indicators_blocks_imagery_order_idx": {
+          "name": "indicators_blocks_imagery_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_blocks_imagery_parent_id_idx": {
+          "name": "indicators_blocks_imagery_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_blocks_imagery_path_idx": {
+          "name": "indicators_blocks_imagery_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "indicators_blocks_imagery_parent_id_fk": {
+          "name": "indicators_blocks_imagery_parent_id_fk",
+          "tableFrom": "indicators_blocks_imagery",
+          "tableTo": "indicators",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicators_blocks_imagery_tile_legend_items": {
+      "name": "indicators_blocks_imagery_tile_legend_items",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indicators_blocks_imagery_tile_legend_items_order_idx": {
+          "name": "indicators_blocks_imagery_tile_legend_items_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_blocks_imagery_tile_legend_items_parent_id_idx": {
+          "name": "indicators_blocks_imagery_tile_legend_items_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "indicators_blocks_imagery_tile_legend_items_parent_id_fk": {
+          "name": "indicators_blocks_imagery_tile_legend_items_parent_id_fk",
+          "tableFrom": "indicators_blocks_imagery_tile_legend_items",
+          "tableTo": "indicators_blocks_imagery_tile",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicators_blocks_imagery_tile_legend_items_locales": {
+      "name": "indicators_blocks_imagery_tile_legend_items_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "indicators_blocks_imagery_tile_legend_items_locales_locale_p": {
+          "name": "indicators_blocks_imagery_tile_legend_items_locales_locale_p",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "indicators_blocks_imagery_tile_legend_items_locales_paren_fk": {
+          "name": "indicators_blocks_imagery_tile_legend_items_locales_paren_fk",
+          "tableFrom": "indicators_blocks_imagery_tile_legend_items_locales",
+          "tableTo": "indicators_blocks_imagery_tile_legend_items",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicators_blocks_imagery_tile": {
+      "name": "indicators_blocks_imagery_tile",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raster_function": {
+          "name": "raster_function",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legend_type": {
+          "name": "legend_type",
+          "type": "enum_indicators_blocks_imagery_tile_legend_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'basic'"
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indicators_blocks_imagery_tile_order_idx": {
+          "name": "indicators_blocks_imagery_tile_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_blocks_imagery_tile_parent_id_idx": {
+          "name": "indicators_blocks_imagery_tile_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_blocks_imagery_tile_path_idx": {
+          "name": "indicators_blocks_imagery_tile_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "indicators_blocks_imagery_tile_parent_id_fk": {
+          "name": "indicators_blocks_imagery_tile_parent_id_fk",
+          "tableFrom": "indicators_blocks_imagery_tile",
+          "tableTo": "indicators",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicators_blocks_web_tile": {
+      "name": "indicators_blocks_web_tile",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indicators_blocks_web_tile_order_idx": {
+          "name": "indicators_blocks_web_tile_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_blocks_web_tile_parent_id_idx": {
+          "name": "indicators_blocks_web_tile_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_blocks_web_tile_path_idx": {
+          "name": "indicators_blocks_web_tile_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "indicators_blocks_web_tile_parent_id_fk": {
+          "name": "indicators_blocks_web_tile_parent_id_fk",
+          "tableFrom": "indicators_blocks_web_tile",
+          "tableTo": "indicators",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicators_blocks_h3": {
+      "name": "indicators_blocks_h3",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column": {
+          "name": "column",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indicators_blocks_h3_order_idx": {
+          "name": "indicators_blocks_h3_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_blocks_h3_parent_id_idx": {
+          "name": "indicators_blocks_h3_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_blocks_h3_path_idx": {
+          "name": "indicators_blocks_h3_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "indicators_blocks_h3_parent_id_fk": {
+          "name": "indicators_blocks_h3_parent_id_fk",
+          "tableFrom": "indicators_blocks_h3",
+          "tableTo": "indicators",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicators_blocks_component": {
+      "name": "indicators_blocks_component",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_ai": {
+          "name": "query_ai",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "indicators_blocks_component_order_idx": {
+          "name": "indicators_blocks_component_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_blocks_component_parent_id_idx": {
+          "name": "indicators_blocks_component_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_blocks_component_path_idx": {
+          "name": "indicators_blocks_component_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "indicators_blocks_component_parent_id_fk": {
+          "name": "indicators_blocks_component_parent_id_fk",
+          "tableFrom": "indicators_blocks_component",
+          "tableTo": "indicators",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicators": {
+      "name": "indicators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtopic_id": {
+          "name": "subtopic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_indicators_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "indicators_legacy_id_idx": {
+          "name": "indicators_legacy_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_subtopic_idx": {
+          "name": "indicators_subtopic_idx",
+          "columns": [
+            {
+              "expression": "subtopic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_updated_at_idx": {
+          "name": "indicators_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators_created_at_idx": {
+          "name": "indicators_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indicators__status_idx": {
+          "name": "indicators__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "indicators_subtopic_id_subtopics_id_fk": {
+          "name": "indicators_subtopic_id_subtopics_id_fk",
+          "tableFrom": "indicators",
+          "tableTo": "subtopics",
+          "columnsFrom": [
+            "subtopic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indicators_locales": {
+      "name": "indicators_locales",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_short": {
+          "name": "description_short",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "indicators_locales_locale_parent_id_unique": {
+          "name": "indicators_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "indicators_locales_parent_id_fk": {
+          "name": "indicators_locales_parent_id_fk",
+          "tableFrom": "indicators_locales",
+          "tableTo": "indicators",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._indicators_v_version_visualization_types": {
+      "name": "_indicators_v_version_visualization_types",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum__indicators_v_version_visualization_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        }
+      },
+      "indexes": {
+        "_indicators_v_version_visualization_types_order_idx": {
+          "name": "_indicators_v_version_visualization_types_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_version_visualization_types_parent_idx": {
+          "name": "_indicators_v_version_visualization_types_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_indicators_v_version_visualization_types_parent_fk": {
+          "name": "_indicators_v_version_visualization_types_parent_fk",
+          "tableFrom": "_indicators_v_version_visualization_types",
+          "tableTo": "_indicators_v",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._indicators_v_blocks_feature_popup_template_field_infos": {
+      "name": "_indicators_v_blocks_feature_popup_template_field_infos",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_indicators_v_blocks_feature_popup_template_field_infos_order_idx": {
+          "name": "_indicators_v_blocks_feature_popup_template_field_infos_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_blocks_feature_popup_template_field_infos_parent_id_idx": {
+          "name": "_indicators_v_blocks_feature_popup_template_field_infos_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_indicators_v_blocks_feature_popup_template_field_infos_parent_id_fk": {
+          "name": "_indicators_v_blocks_feature_popup_template_field_infos_parent_id_fk",
+          "tableFrom": "_indicators_v_blocks_feature_popup_template_field_infos",
+          "tableTo": "_indicators_v_blocks_feature",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._indicators_v_blocks_feature_popup_template_field_infos_locales": {
+      "name": "_indicators_v_blocks_feature_popup_template_field_infos_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_indicators_v_blocks_feature_popup_template_field_infos_loca": {
+          "name": "_indicators_v_blocks_feature_popup_template_field_infos_loca",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_indicators_v_blocks_feature_popup_template_field_infos_l_fk": {
+          "name": "_indicators_v_blocks_feature_popup_template_field_infos_l_fk",
+          "tableFrom": "_indicators_v_blocks_feature_popup_template_field_infos_locales",
+          "tableTo": "_indicators_v_blocks_feature_popup_template_field_infos",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._indicators_v_blocks_feature": {
+      "name": "_indicators_v_blocks_feature",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layer_id": {
+          "name": "layer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "popup_template_title": {
+          "name": "popup_template_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_numeric": {
+          "name": "query_numeric",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_table": {
+          "name": "query_table",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_chart": {
+          "name": "query_chart",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_ai": {
+          "name": "query_ai",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_indicators_v_blocks_feature_order_idx": {
+          "name": "_indicators_v_blocks_feature_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_blocks_feature_parent_id_idx": {
+          "name": "_indicators_v_blocks_feature_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_blocks_feature_path_idx": {
+          "name": "_indicators_v_blocks_feature_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_indicators_v_blocks_feature_parent_id_fk": {
+          "name": "_indicators_v_blocks_feature_parent_id_fk",
+          "tableFrom": "_indicators_v_blocks_feature",
+          "tableTo": "_indicators_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._indicators_v_blocks_imagery_legend_items": {
+      "name": "_indicators_v_blocks_imagery_legend_items",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_indicators_v_blocks_imagery_legend_items_order_idx": {
+          "name": "_indicators_v_blocks_imagery_legend_items_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_blocks_imagery_legend_items_parent_id_idx": {
+          "name": "_indicators_v_blocks_imagery_legend_items_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_indicators_v_blocks_imagery_legend_items_parent_id_fk": {
+          "name": "_indicators_v_blocks_imagery_legend_items_parent_id_fk",
+          "tableFrom": "_indicators_v_blocks_imagery_legend_items",
+          "tableTo": "_indicators_v_blocks_imagery",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._indicators_v_blocks_imagery_legend_items_locales": {
+      "name": "_indicators_v_blocks_imagery_legend_items_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_indicators_v_blocks_imagery_legend_items_locales_locale_par": {
+          "name": "_indicators_v_blocks_imagery_legend_items_locales_locale_par",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_indicators_v_blocks_imagery_legend_items_locales_parent__fk": {
+          "name": "_indicators_v_blocks_imagery_legend_items_locales_parent__fk",
+          "tableFrom": "_indicators_v_blocks_imagery_legend_items_locales",
+          "tableTo": "_indicators_v_blocks_imagery_legend_items",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._indicators_v_blocks_imagery": {
+      "name": "_indicators_v_blocks_imagery",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raster_function": {
+          "name": "raster_function",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legend_type": {
+          "name": "legend_type",
+          "type": "enum__indicators_v_blocks_imagery_legend_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'basic'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_indicators_v_blocks_imagery_order_idx": {
+          "name": "_indicators_v_blocks_imagery_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_blocks_imagery_parent_id_idx": {
+          "name": "_indicators_v_blocks_imagery_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_blocks_imagery_path_idx": {
+          "name": "_indicators_v_blocks_imagery_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_indicators_v_blocks_imagery_parent_id_fk": {
+          "name": "_indicators_v_blocks_imagery_parent_id_fk",
+          "tableFrom": "_indicators_v_blocks_imagery",
+          "tableTo": "_indicators_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._indicators_v_blocks_imagery_tile_legend_items": {
+      "name": "_indicators_v_blocks_imagery_tile_legend_items",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_indicators_v_blocks_imagery_tile_legend_items_order_idx": {
+          "name": "_indicators_v_blocks_imagery_tile_legend_items_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_blocks_imagery_tile_legend_items_parent_id_idx": {
+          "name": "_indicators_v_blocks_imagery_tile_legend_items_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_indicators_v_blocks_imagery_tile_legend_items_parent_id_fk": {
+          "name": "_indicators_v_blocks_imagery_tile_legend_items_parent_id_fk",
+          "tableFrom": "_indicators_v_blocks_imagery_tile_legend_items",
+          "tableTo": "_indicators_v_blocks_imagery_tile",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._indicators_v_blocks_imagery_tile_legend_items_locales": {
+      "name": "_indicators_v_blocks_imagery_tile_legend_items_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_indicators_v_blocks_imagery_tile_legend_items_locales_local": {
+          "name": "_indicators_v_blocks_imagery_tile_legend_items_locales_local",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_indicators_v_blocks_imagery_tile_legend_items_locales_pa_fk": {
+          "name": "_indicators_v_blocks_imagery_tile_legend_items_locales_pa_fk",
+          "tableFrom": "_indicators_v_blocks_imagery_tile_legend_items_locales",
+          "tableTo": "_indicators_v_blocks_imagery_tile_legend_items",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._indicators_v_blocks_imagery_tile": {
+      "name": "_indicators_v_blocks_imagery_tile",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raster_function": {
+          "name": "raster_function",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legend_type": {
+          "name": "legend_type",
+          "type": "enum__indicators_v_blocks_imagery_tile_legend_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'basic'"
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_indicators_v_blocks_imagery_tile_order_idx": {
+          "name": "_indicators_v_blocks_imagery_tile_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_blocks_imagery_tile_parent_id_idx": {
+          "name": "_indicators_v_blocks_imagery_tile_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_blocks_imagery_tile_path_idx": {
+          "name": "_indicators_v_blocks_imagery_tile_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_indicators_v_blocks_imagery_tile_parent_id_fk": {
+          "name": "_indicators_v_blocks_imagery_tile_parent_id_fk",
+          "tableFrom": "_indicators_v_blocks_imagery_tile",
+          "tableTo": "_indicators_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._indicators_v_blocks_web_tile": {
+      "name": "_indicators_v_blocks_web_tile",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_indicators_v_blocks_web_tile_order_idx": {
+          "name": "_indicators_v_blocks_web_tile_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_blocks_web_tile_parent_id_idx": {
+          "name": "_indicators_v_blocks_web_tile_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_blocks_web_tile_path_idx": {
+          "name": "_indicators_v_blocks_web_tile_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_indicators_v_blocks_web_tile_parent_id_fk": {
+          "name": "_indicators_v_blocks_web_tile_parent_id_fk",
+          "tableFrom": "_indicators_v_blocks_web_tile",
+          "tableTo": "_indicators_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._indicators_v_blocks_h3": {
+      "name": "_indicators_v_blocks_h3",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column": {
+          "name": "column",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_indicators_v_blocks_h3_order_idx": {
+          "name": "_indicators_v_blocks_h3_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_blocks_h3_parent_id_idx": {
+          "name": "_indicators_v_blocks_h3_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_blocks_h3_path_idx": {
+          "name": "_indicators_v_blocks_h3_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_indicators_v_blocks_h3_parent_id_fk": {
+          "name": "_indicators_v_blocks_h3_parent_id_fk",
+          "tableFrom": "_indicators_v_blocks_h3",
+          "tableTo": "_indicators_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._indicators_v_blocks_component": {
+      "name": "_indicators_v_blocks_component",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_ai": {
+          "name": "query_ai",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_indicators_v_blocks_component_order_idx": {
+          "name": "_indicators_v_blocks_component_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_blocks_component_parent_id_idx": {
+          "name": "_indicators_v_blocks_component_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_blocks_component_path_idx": {
+          "name": "_indicators_v_blocks_component_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_indicators_v_blocks_component_parent_id_fk": {
+          "name": "_indicators_v_blocks_component_parent_id_fk",
+          "tableFrom": "_indicators_v_blocks_component",
+          "tableTo": "_indicators_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._indicators_v": {
+      "name": "_indicators_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_legacy_id": {
+          "name": "version_legacy_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_order": {
+          "name": "version_order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_subtopic_id": {
+          "name": "version_subtopic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__indicators_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_locale": {
+          "name": "published_locale",
+          "type": "enum__indicators_v_published_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_indicators_v_parent_idx": {
+          "name": "_indicators_v_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_version_version_legacy_id_idx": {
+          "name": "_indicators_v_version_version_legacy_id_idx",
+          "columns": [
+            {
+              "expression": "version_legacy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_version_version_subtopic_idx": {
+          "name": "_indicators_v_version_version_subtopic_idx",
+          "columns": [
+            {
+              "expression": "version_subtopic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_version_version_updated_at_idx": {
+          "name": "_indicators_v_version_version_updated_at_idx",
+          "columns": [
+            {
+              "expression": "version_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_version_version_created_at_idx": {
+          "name": "_indicators_v_version_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "version_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_version_version__status_idx": {
+          "name": "_indicators_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_created_at_idx": {
+          "name": "_indicators_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_updated_at_idx": {
+          "name": "_indicators_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_snapshot_idx": {
+          "name": "_indicators_v_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_published_locale_idx": {
+          "name": "_indicators_v_published_locale_idx",
+          "columns": [
+            {
+              "expression": "published_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_indicators_v_latest_idx": {
+          "name": "_indicators_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_indicators_v_parent_id_indicators_id_fk": {
+          "name": "_indicators_v_parent_id_indicators_id_fk",
+          "tableFrom": "_indicators_v",
+          "tableTo": "indicators",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_indicators_v_version_subtopic_id_subtopics_id_fk": {
+          "name": "_indicators_v_version_subtopic_id_subtopics_id_fk",
+          "tableFrom": "_indicators_v",
+          "tableTo": "subtopics",
+          "columnsFrom": [
+            "version_subtopic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._indicators_v_locales": {
+      "name": "_indicators_v_locales",
+      "schema": "",
+      "columns": {
+        "version_name": {
+          "name": "version_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_unit": {
+          "name": "version_unit",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_description_short": {
+          "name": "version_description_short",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_description": {
+          "name": "version_description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_indicators_v_locales_locale_parent_id_unique": {
+          "name": "_indicators_v_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_indicators_v_locales_parent_id_fk": {
+          "name": "_indicators_v_locales_parent_id_fk",
+          "tableFrom": "_indicators_v_locales",
+          "tableTo": "_indicators_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_jobs_log": {
+      "name": "payload_jobs_log",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_slug": {
+          "name": "task_slug",
+          "type": "enum_payload_jobs_log_task_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_i_d": {
+          "name": "task_i_d",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum_payload_jobs_log_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_jobs_log_order_idx": {
+          "name": "payload_jobs_log_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_log_parent_id_idx": {
+          "name": "payload_jobs_log_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_jobs_log_parent_id_fk": {
+          "name": "payload_jobs_log_parent_id_fk",
+          "tableFrom": "payload_jobs_log",
+          "tableTo": "payload_jobs",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_jobs": {
+      "name": "payload_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tried": {
+          "name": "total_tried",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "has_error": {
+          "name": "has_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_slug": {
+          "name": "task_slug",
+          "type": "enum_payload_jobs_task_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queue": {
+          "name": "queue",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "wait_until": {
+          "name": "wait_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing": {
+          "name": "processing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_jobs_completed_at_idx": {
+          "name": "payload_jobs_completed_at_idx",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_total_tried_idx": {
+          "name": "payload_jobs_total_tried_idx",
+          "columns": [
+            {
+              "expression": "total_tried",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_has_error_idx": {
+          "name": "payload_jobs_has_error_idx",
+          "columns": [
+            {
+              "expression": "has_error",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_task_slug_idx": {
+          "name": "payload_jobs_task_slug_idx",
+          "columns": [
+            {
+              "expression": "task_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_queue_idx": {
+          "name": "payload_jobs_queue_idx",
+          "columns": [
+            {
+              "expression": "queue",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_wait_until_idx": {
+          "name": "payload_jobs_wait_until_idx",
+          "columns": [
+            {
+              "expression": "wait_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_processing_idx": {
+          "name": "payload_jobs_processing_idx",
+          "columns": [
+            {
+              "expression": "processing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_updated_at_idx": {
+          "name": "payload_jobs_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_created_at_idx": {
+          "name": "payload_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admins_id": {
+          "name": "admins_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_users_id": {
+          "name": "anonymous_users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts_id": {
+          "name": "accounts_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reports_id": {
+          "name": "reports_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics_id": {
+          "name": "topics_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtopics_id": {
+          "name": "subtopics_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicators_id": {
+          "name": "indicators_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_admins_id_idx": {
+          "name": "payload_locked_documents_rels_admins_id_idx",
+          "columns": [
+            {
+              "expression": "admins_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_anonymous_users_id_idx": {
+          "name": "payload_locked_documents_rels_anonymous_users_id_idx",
+          "columns": [
+            {
+              "expression": "anonymous_users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_accounts_id_idx": {
+          "name": "payload_locked_documents_rels_accounts_id_idx",
+          "columns": [
+            {
+              "expression": "accounts_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_media_id_idx": {
+          "name": "payload_locked_documents_rels_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_reports_id_idx": {
+          "name": "payload_locked_documents_rels_reports_id_idx",
+          "columns": [
+            {
+              "expression": "reports_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_topics_id_idx": {
+          "name": "payload_locked_documents_rels_topics_id_idx",
+          "columns": [
+            {
+              "expression": "topics_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_subtopics_id_idx": {
+          "name": "payload_locked_documents_rels_subtopics_id_idx",
+          "columns": [
+            {
+              "expression": "subtopics_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_indicators_id_idx": {
+          "name": "payload_locked_documents_rels_indicators_id_idx",
+          "columns": [
+            {
+              "expression": "indicators_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_admins_fk": {
+          "name": "payload_locked_documents_rels_admins_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "admins",
+          "columnsFrom": [
+            "admins_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_anonymous_users_fk": {
+          "name": "payload_locked_documents_rels_anonymous_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "anonymous_users",
+          "columnsFrom": [
+            "anonymous_users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_accounts_fk": {
+          "name": "payload_locked_documents_rels_accounts_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "accounts_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_media_fk": {
+          "name": "payload_locked_documents_rels_media_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_reports_fk": {
+          "name": "payload_locked_documents_rels_reports_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "reports",
+          "columnsFrom": [
+            "reports_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_topics_fk": {
+          "name": "payload_locked_documents_rels_topics_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topics_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_subtopics_fk": {
+          "name": "payload_locked_documents_rels_subtopics_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "subtopics",
+          "columnsFrom": [
+            "subtopics_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_indicators_fk": {
+          "name": "payload_locked_documents_rels_indicators_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "indicators",
+          "columnsFrom": [
+            "indicators_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admins_id": {
+          "name": "admins_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_users_id": {
+          "name": "anonymous_users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_admins_id_idx": {
+          "name": "payload_preferences_rels_admins_id_idx",
+          "columns": [
+            {
+              "expression": "admins_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_anonymous_users_id_idx": {
+          "name": "payload_preferences_rels_anonymous_users_id_idx",
+          "columns": [
+            {
+              "expression": "anonymous_users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_admins_fk": {
+          "name": "payload_preferences_rels_admins_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "admins",
+          "columnsFrom": [
+            "admins_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_anonymous_users_fk": {
+          "name": "payload_preferences_rels_anonymous_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "anonymous_users",
+          "columnsFrom": [
+            "anonymous_users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_jobs_stats": {
+      "name": "payload_jobs_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public._locales": {
+      "name": "_locales",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "pt"
+      ]
+    },
+    "public.enum_reports_topics_indicators_type": {
+      "name": "enum_reports_topics_indicators_type",
+      "schema": "public",
+      "values": [
+        "map",
+        "chart",
+        "table",
+        "numeric",
+        "custom",
+        "ai"
+      ]
+    },
+    "public.enum_reports_topics_indicators_basemap_id": {
+      "name": "enum_reports_topics_indicators_basemap_id",
+      "schema": "public",
+      "values": [
+        "gray-vector",
+        "dark-gray-vector",
+        "satellite",
+        "streets",
+        "hybrid",
+        "osm",
+        "topo-vector",
+        "terrain"
+      ]
+    },
+    "public.enum_reports_status": {
+      "name": "enum_reports_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__reports_v_version_topics_indicators_type": {
+      "name": "enum__reports_v_version_topics_indicators_type",
+      "schema": "public",
+      "values": [
+        "map",
+        "chart",
+        "table",
+        "numeric",
+        "custom",
+        "ai"
+      ]
+    },
+    "public.enum__reports_v_version_topics_indicators_basemap_id": {
+      "name": "enum__reports_v_version_topics_indicators_basemap_id",
+      "schema": "public",
+      "values": [
+        "gray-vector",
+        "dark-gray-vector",
+        "satellite",
+        "streets",
+        "hybrid",
+        "osm",
+        "topo-vector",
+        "terrain"
+      ]
+    },
+    "public.enum__reports_v_version_status": {
+      "name": "enum__reports_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__reports_v_published_locale": {
+      "name": "enum__reports_v_published_locale",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "pt"
+      ]
+    },
+    "public.enum_topics_default_visualization_type": {
+      "name": "enum_topics_default_visualization_type",
+      "schema": "public",
+      "values": [
+        "map",
+        "chart",
+        "table",
+        "numeric",
+        "custom",
+        "ai"
+      ]
+    },
+    "public.enum_topics_default_visualization_basemap_id": {
+      "name": "enum_topics_default_visualization_basemap_id",
+      "schema": "public",
+      "values": [
+        "gray-vector",
+        "dark-gray-vector",
+        "satellite",
+        "streets",
+        "hybrid",
+        "osm",
+        "topo-vector",
+        "terrain"
+      ]
+    },
+    "public.enum_topics_status": {
+      "name": "enum_topics_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__topics_v_version_default_visualization_type": {
+      "name": "enum__topics_v_version_default_visualization_type",
+      "schema": "public",
+      "values": [
+        "map",
+        "chart",
+        "table",
+        "numeric",
+        "custom",
+        "ai"
+      ]
+    },
+    "public.enum__topics_v_version_default_visualization_basemap_id": {
+      "name": "enum__topics_v_version_default_visualization_basemap_id",
+      "schema": "public",
+      "values": [
+        "gray-vector",
+        "dark-gray-vector",
+        "satellite",
+        "streets",
+        "hybrid",
+        "osm",
+        "topo-vector",
+        "terrain"
+      ]
+    },
+    "public.enum__topics_v_version_status": {
+      "name": "enum__topics_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__topics_v_published_locale": {
+      "name": "enum__topics_v_published_locale",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "pt"
+      ]
+    },
+    "public.enum_subtopics_default_visualization_type": {
+      "name": "enum_subtopics_default_visualization_type",
+      "schema": "public",
+      "values": [
+        "map",
+        "chart",
+        "table",
+        "numeric",
+        "custom",
+        "ai"
+      ]
+    },
+    "public.enum_subtopics_default_visualization_basemap_id": {
+      "name": "enum_subtopics_default_visualization_basemap_id",
+      "schema": "public",
+      "values": [
+        "gray-vector",
+        "dark-gray-vector",
+        "satellite",
+        "streets",
+        "hybrid",
+        "osm",
+        "topo-vector",
+        "terrain"
+      ]
+    },
+    "public.enum_subtopics_status": {
+      "name": "enum_subtopics_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__subtopics_v_version_default_visualization_type": {
+      "name": "enum__subtopics_v_version_default_visualization_type",
+      "schema": "public",
+      "values": [
+        "map",
+        "chart",
+        "table",
+        "numeric",
+        "custom",
+        "ai"
+      ]
+    },
+    "public.enum__subtopics_v_version_default_visualization_basemap_id": {
+      "name": "enum__subtopics_v_version_default_visualization_basemap_id",
+      "schema": "public",
+      "values": [
+        "gray-vector",
+        "dark-gray-vector",
+        "satellite",
+        "streets",
+        "hybrid",
+        "osm",
+        "topo-vector",
+        "terrain"
+      ]
+    },
+    "public.enum__subtopics_v_version_status": {
+      "name": "enum__subtopics_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__subtopics_v_published_locale": {
+      "name": "enum__subtopics_v_published_locale",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "pt"
+      ]
+    },
+    "public.enum_indicators_visualization_types": {
+      "name": "enum_indicators_visualization_types",
+      "schema": "public",
+      "values": [
+        "map",
+        "table",
+        "chart",
+        "numeric"
+      ]
+    },
+    "public.enum_indicators_blocks_imagery_legend_type": {
+      "name": "enum_indicators_blocks_imagery_legend_type",
+      "schema": "public",
+      "values": [
+        "basic"
+      ]
+    },
+    "public.enum_indicators_blocks_imagery_tile_legend_type": {
+      "name": "enum_indicators_blocks_imagery_tile_legend_type",
+      "schema": "public",
+      "values": [
+        "basic"
+      ]
+    },
+    "public.enum_indicators_status": {
+      "name": "enum_indicators_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__indicators_v_version_visualization_types": {
+      "name": "enum__indicators_v_version_visualization_types",
+      "schema": "public",
+      "values": [
+        "map",
+        "table",
+        "chart",
+        "numeric"
+      ]
+    },
+    "public.enum__indicators_v_blocks_imagery_legend_type": {
+      "name": "enum__indicators_v_blocks_imagery_legend_type",
+      "schema": "public",
+      "values": [
+        "basic"
+      ]
+    },
+    "public.enum__indicators_v_blocks_imagery_tile_legend_type": {
+      "name": "enum__indicators_v_blocks_imagery_tile_legend_type",
+      "schema": "public",
+      "values": [
+        "basic"
+      ]
+    },
+    "public.enum__indicators_v_version_status": {
+      "name": "enum__indicators_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__indicators_v_published_locale": {
+      "name": "enum__indicators_v_published_locale",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "pt"
+      ]
+    },
+    "public.enum_payload_jobs_log_task_slug": {
+      "name": "enum_payload_jobs_log_task_slug",
+      "schema": "public",
+      "values": [
+        "inline",
+        "CleanAnonymousUsers",
+        "CleanDraftReports"
+      ]
+    },
+    "public.enum_payload_jobs_log_state": {
+      "name": "enum_payload_jobs_log_state",
+      "schema": "public",
+      "values": [
+        "failed",
+        "succeeded"
+      ]
+    },
+    "public.enum_payload_jobs_task_slug": {
+      "name": "enum_payload_jobs_task_slug",
+      "schema": "public",
+      "values": [
+        "inline",
+        "CleanAnonymousUsers",
+        "CleanDraftReports"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "9e5caf04-315a-480f-a532-c6cba8cffe03",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/client/src/cms/migrations/20260803_090559.ts
+++ b/client/src/cms/migrations/20260803_090559.ts
@@ -1,0 +1,772 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   CREATE TYPE "public"."enum_topics_default_visualization_type" AS ENUM('map', 'chart', 'table', 'numeric', 'custom', 'ai');
+  CREATE TYPE "public"."enum_topics_default_visualization_basemap_id" AS ENUM('gray-vector', 'dark-gray-vector', 'satellite', 'streets', 'hybrid', 'osm', 'topo-vector', 'terrain');
+  CREATE TYPE "public"."enum_topics_status" AS ENUM('draft', 'published');
+  CREATE TYPE "public"."enum__topics_v_version_default_visualization_type" AS ENUM('map', 'chart', 'table', 'numeric', 'custom', 'ai');
+  CREATE TYPE "public"."enum__topics_v_version_default_visualization_basemap_id" AS ENUM('gray-vector', 'dark-gray-vector', 'satellite', 'streets', 'hybrid', 'osm', 'topo-vector', 'terrain');
+  CREATE TYPE "public"."enum__topics_v_version_status" AS ENUM('draft', 'published');
+  CREATE TYPE "public"."enum__topics_v_published_locale" AS ENUM('en', 'es', 'pt');
+  CREATE TYPE "public"."enum_subtopics_default_visualization_type" AS ENUM('map', 'chart', 'table', 'numeric', 'custom', 'ai');
+  CREATE TYPE "public"."enum_subtopics_default_visualization_basemap_id" AS ENUM('gray-vector', 'dark-gray-vector', 'satellite', 'streets', 'hybrid', 'osm', 'topo-vector', 'terrain');
+  CREATE TYPE "public"."enum_subtopics_status" AS ENUM('draft', 'published');
+  CREATE TYPE "public"."enum__subtopics_v_version_default_visualization_type" AS ENUM('map', 'chart', 'table', 'numeric', 'custom', 'ai');
+  CREATE TYPE "public"."enum__subtopics_v_version_default_visualization_basemap_id" AS ENUM('gray-vector', 'dark-gray-vector', 'satellite', 'streets', 'hybrid', 'osm', 'topo-vector', 'terrain');
+  CREATE TYPE "public"."enum__subtopics_v_version_status" AS ENUM('draft', 'published');
+  CREATE TYPE "public"."enum__subtopics_v_published_locale" AS ENUM('en', 'es', 'pt');
+  CREATE TYPE "public"."enum_indicators_visualization_types" AS ENUM('map', 'table', 'chart', 'numeric');
+  CREATE TYPE "public"."enum_indicators_blocks_imagery_legend_type" AS ENUM('basic');
+  CREATE TYPE "public"."enum_indicators_blocks_imagery_tile_legend_type" AS ENUM('basic');
+  CREATE TYPE "public"."enum_indicators_status" AS ENUM('draft', 'published');
+  CREATE TYPE "public"."enum__indicators_v_version_visualization_types" AS ENUM('map', 'table', 'chart', 'numeric');
+  CREATE TYPE "public"."enum__indicators_v_blocks_imagery_legend_type" AS ENUM('basic');
+  CREATE TYPE "public"."enum__indicators_v_blocks_imagery_tile_legend_type" AS ENUM('basic');
+  CREATE TYPE "public"."enum__indicators_v_version_status" AS ENUM('draft', 'published');
+  CREATE TYPE "public"."enum__indicators_v_published_locale" AS ENUM('en', 'es', 'pt');
+  ALTER TYPE "public"."enum_payload_jobs_log_task_slug" ADD VALUE 'CleanDraftReports';
+  ALTER TYPE "public"."enum_payload_jobs_task_slug" ADD VALUE 'CleanDraftReports';
+  CREATE TABLE "topics_default_visualization" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"indicator_id" uuid,
+  	"type" "enum_topics_default_visualization_type",
+  	"x" numeric,
+  	"y" numeric,
+  	"w" numeric,
+  	"h" numeric,
+  	"basemap_id" "enum_topics_default_visualization_basemap_id" DEFAULT 'gray-vector',
+  	"opacity" numeric DEFAULT 1
+  );
+  
+  CREATE TABLE "topics" (
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"legacy_id" numeric,
+  	"image" varchar,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"_status" "enum_topics_status" DEFAULT 'draft'
+  );
+  
+  CREATE TABLE "topics_locales" (
+  	"name" varchar,
+  	"description" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" uuid NOT NULL
+  );
+  
+  CREATE TABLE "_topics_v_version_default_visualization" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"indicator_id" uuid,
+  	"type" "enum__topics_v_version_default_visualization_type",
+  	"x" numeric,
+  	"y" numeric,
+  	"w" numeric,
+  	"h" numeric,
+  	"basemap_id" "enum__topics_v_version_default_visualization_basemap_id" DEFAULT 'gray-vector',
+  	"opacity" numeric DEFAULT 1,
+  	"_uuid" varchar
+  );
+  
+  CREATE TABLE "_topics_v" (
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"parent_id" uuid,
+  	"version_legacy_id" numeric,
+  	"version_image" varchar,
+  	"version_updated_at" timestamp(3) with time zone,
+  	"version_created_at" timestamp(3) with time zone,
+  	"version__status" "enum__topics_v_version_status" DEFAULT 'draft',
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"snapshot" boolean,
+  	"published_locale" "enum__topics_v_published_locale",
+  	"latest" boolean
+  );
+  
+  CREATE TABLE "_topics_v_locales" (
+  	"version_name" varchar,
+  	"version_description" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" uuid NOT NULL
+  );
+  
+  CREATE TABLE "subtopics_default_visualization" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"indicator_id" uuid,
+  	"type" "enum_subtopics_default_visualization_type",
+  	"x" numeric,
+  	"y" numeric,
+  	"w" numeric,
+  	"h" numeric,
+  	"basemap_id" "enum_subtopics_default_visualization_basemap_id" DEFAULT 'gray-vector',
+  	"opacity" numeric DEFAULT 1
+  );
+  
+  CREATE TABLE "subtopics" (
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"legacy_id" numeric,
+  	"topic_id" uuid,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"_status" "enum_subtopics_status" DEFAULT 'draft'
+  );
+  
+  CREATE TABLE "subtopics_locales" (
+  	"name" varchar,
+  	"description" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" uuid NOT NULL
+  );
+  
+  CREATE TABLE "_subtopics_v_version_default_visualization" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"indicator_id" uuid,
+  	"type" "enum__subtopics_v_version_default_visualization_type",
+  	"x" numeric,
+  	"y" numeric,
+  	"w" numeric,
+  	"h" numeric,
+  	"basemap_id" "enum__subtopics_v_version_default_visualization_basemap_id" DEFAULT 'gray-vector',
+  	"opacity" numeric DEFAULT 1,
+  	"_uuid" varchar
+  );
+  
+  CREATE TABLE "_subtopics_v" (
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"parent_id" uuid,
+  	"version_legacy_id" numeric,
+  	"version_topic_id" uuid,
+  	"version_updated_at" timestamp(3) with time zone,
+  	"version_created_at" timestamp(3) with time zone,
+  	"version__status" "enum__subtopics_v_version_status" DEFAULT 'draft',
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"snapshot" boolean,
+  	"published_locale" "enum__subtopics_v_published_locale",
+  	"latest" boolean
+  );
+  
+  CREATE TABLE "_subtopics_v_locales" (
+  	"version_name" varchar,
+  	"version_description" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" uuid NOT NULL
+  );
+  
+  CREATE TABLE "indicators_visualization_types" (
+  	"order" integer NOT NULL,
+  	"parent_id" uuid NOT NULL,
+  	"value" "enum_indicators_visualization_types",
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL
+  );
+  
+  CREATE TABLE "indicators_blocks_feature_popup_template_field_infos" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" varchar NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"field_name" varchar
+  );
+  
+  CREATE TABLE "indicators_blocks_feature_popup_template_field_infos_locales" (
+  	"label" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" varchar NOT NULL
+  );
+  
+  CREATE TABLE "indicators_blocks_feature" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"_path" text NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"name" varchar,
+  	"url" varchar,
+  	"layer_id" varchar DEFAULT '0',
+  	"popup_template_title" varchar,
+  	"query_numeric" jsonb,
+  	"query_table" jsonb,
+  	"query_chart" jsonb,
+  	"query_ai" jsonb,
+  	"block_name" varchar
+  );
+  
+  CREATE TABLE "indicators_blocks_imagery_legend_items" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" varchar NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"color" varchar
+  );
+  
+  CREATE TABLE "indicators_blocks_imagery_legend_items_locales" (
+  	"label" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" varchar NOT NULL
+  );
+  
+  CREATE TABLE "indicators_blocks_imagery" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"_path" text NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"name" varchar,
+  	"url" varchar,
+  	"raster_function" jsonb,
+  	"legend_type" "enum_indicators_blocks_imagery_legend_type" DEFAULT 'basic',
+  	"block_name" varchar
+  );
+  
+  CREATE TABLE "indicators_blocks_imagery_tile_legend_items" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" varchar NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"color" varchar
+  );
+  
+  CREATE TABLE "indicators_blocks_imagery_tile_legend_items_locales" (
+  	"label" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" varchar NOT NULL
+  );
+  
+  CREATE TABLE "indicators_blocks_imagery_tile" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"_path" text NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"name" varchar,
+  	"url" varchar,
+  	"raster_function" jsonb,
+  	"legend_type" "enum_indicators_blocks_imagery_tile_legend_type" DEFAULT 'basic',
+  	"block_name" varchar
+  );
+  
+  CREATE TABLE "indicators_blocks_web_tile" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"_path" text NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"name" varchar,
+  	"url" varchar,
+  	"block_name" varchar
+  );
+  
+  CREATE TABLE "indicators_blocks_h3" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"_path" text NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"name" varchar,
+  	"column" varchar,
+  	"url" varchar,
+  	"block_name" varchar
+  );
+  
+  CREATE TABLE "indicators_blocks_component" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"_path" text NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"name" varchar,
+  	"query_ai" jsonb,
+  	"block_name" varchar
+  );
+  
+  CREATE TABLE "indicators" (
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"legacy_id" numeric,
+  	"order" numeric,
+  	"subtopic_id" uuid,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"_status" "enum_indicators_status" DEFAULT 'draft'
+  );
+  
+  CREATE TABLE "indicators_locales" (
+  	"name" varchar,
+  	"unit" varchar,
+  	"description_short" varchar,
+  	"description" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" uuid NOT NULL
+  );
+  
+  CREATE TABLE "_indicators_v_version_visualization_types" (
+  	"order" integer NOT NULL,
+  	"parent_id" uuid NOT NULL,
+  	"value" "enum__indicators_v_version_visualization_types",
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL
+  );
+  
+  CREATE TABLE "_indicators_v_blocks_feature_popup_template_field_infos" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"field_name" varchar,
+  	"_uuid" varchar
+  );
+  
+  CREATE TABLE "_indicators_v_blocks_feature_popup_template_field_infos_locales" (
+  	"label" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" uuid NOT NULL
+  );
+  
+  CREATE TABLE "_indicators_v_blocks_feature" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"_path" text NOT NULL,
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"name" varchar,
+  	"url" varchar,
+  	"layer_id" varchar DEFAULT '0',
+  	"popup_template_title" varchar,
+  	"query_numeric" jsonb,
+  	"query_table" jsonb,
+  	"query_chart" jsonb,
+  	"query_ai" jsonb,
+  	"_uuid" varchar,
+  	"block_name" varchar
+  );
+  
+  CREATE TABLE "_indicators_v_blocks_imagery_legend_items" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"color" varchar,
+  	"_uuid" varchar
+  );
+  
+  CREATE TABLE "_indicators_v_blocks_imagery_legend_items_locales" (
+  	"label" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" uuid NOT NULL
+  );
+  
+  CREATE TABLE "_indicators_v_blocks_imagery" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"_path" text NOT NULL,
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"name" varchar,
+  	"url" varchar,
+  	"raster_function" jsonb,
+  	"legend_type" "enum__indicators_v_blocks_imagery_legend_type" DEFAULT 'basic',
+  	"_uuid" varchar,
+  	"block_name" varchar
+  );
+  
+  CREATE TABLE "_indicators_v_blocks_imagery_tile_legend_items" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"color" varchar,
+  	"_uuid" varchar
+  );
+  
+  CREATE TABLE "_indicators_v_blocks_imagery_tile_legend_items_locales" (
+  	"label" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" uuid NOT NULL
+  );
+  
+  CREATE TABLE "_indicators_v_blocks_imagery_tile" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"_path" text NOT NULL,
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"name" varchar,
+  	"url" varchar,
+  	"raster_function" jsonb,
+  	"legend_type" "enum__indicators_v_blocks_imagery_tile_legend_type" DEFAULT 'basic',
+  	"_uuid" varchar,
+  	"block_name" varchar
+  );
+  
+  CREATE TABLE "_indicators_v_blocks_web_tile" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"_path" text NOT NULL,
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"name" varchar,
+  	"url" varchar,
+  	"_uuid" varchar,
+  	"block_name" varchar
+  );
+  
+  CREATE TABLE "_indicators_v_blocks_h3" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"_path" text NOT NULL,
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"name" varchar,
+  	"column" varchar,
+  	"url" varchar,
+  	"_uuid" varchar,
+  	"block_name" varchar
+  );
+  
+  CREATE TABLE "_indicators_v_blocks_component" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" uuid NOT NULL,
+  	"_path" text NOT NULL,
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"name" varchar,
+  	"query_ai" jsonb,
+  	"_uuid" varchar,
+  	"block_name" varchar
+  );
+  
+  CREATE TABLE "_indicators_v" (
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"parent_id" uuid,
+  	"version_legacy_id" numeric,
+  	"version_order" numeric,
+  	"version_subtopic_id" uuid,
+  	"version_updated_at" timestamp(3) with time zone,
+  	"version_created_at" timestamp(3) with time zone,
+  	"version__status" "enum__indicators_v_version_status" DEFAULT 'draft',
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"snapshot" boolean,
+  	"published_locale" "enum__indicators_v_published_locale",
+  	"latest" boolean
+  );
+  
+  CREATE TABLE "_indicators_v_locales" (
+  	"version_name" varchar,
+  	"version_unit" varchar,
+  	"version_description_short" varchar,
+  	"version_description" varchar,
+  	"id" serial PRIMARY KEY NOT NULL,
+  	"_locale" "_locales" NOT NULL,
+  	"_parent_id" uuid NOT NULL
+  );
+  
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "topics_id" uuid;
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "subtopics_id" uuid;
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "indicators_id" uuid;
+  ALTER TABLE "topics_default_visualization" ADD CONSTRAINT "topics_default_visualization_indicator_id_indicators_id_fk" FOREIGN KEY ("indicator_id") REFERENCES "public"."indicators"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "topics_default_visualization" ADD CONSTRAINT "topics_default_visualization_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."topics"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "topics_locales" ADD CONSTRAINT "topics_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."topics"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_topics_v_version_default_visualization" ADD CONSTRAINT "_topics_v_version_default_visualization_indicator_id_indicators_id_fk" FOREIGN KEY ("indicator_id") REFERENCES "public"."indicators"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "_topics_v_version_default_visualization" ADD CONSTRAINT "_topics_v_version_default_visualization_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_topics_v"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_topics_v" ADD CONSTRAINT "_topics_v_parent_id_topics_id_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."topics"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "_topics_v_locales" ADD CONSTRAINT "_topics_v_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_topics_v"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "subtopics_default_visualization" ADD CONSTRAINT "subtopics_default_visualization_indicator_id_indicators_id_fk" FOREIGN KEY ("indicator_id") REFERENCES "public"."indicators"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "subtopics_default_visualization" ADD CONSTRAINT "subtopics_default_visualization_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."subtopics"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "subtopics" ADD CONSTRAINT "subtopics_topic_id_topics_id_fk" FOREIGN KEY ("topic_id") REFERENCES "public"."topics"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "subtopics_locales" ADD CONSTRAINT "subtopics_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."subtopics"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_subtopics_v_version_default_visualization" ADD CONSTRAINT "_subtopics_v_version_default_visualization_indicator_id_indicators_id_fk" FOREIGN KEY ("indicator_id") REFERENCES "public"."indicators"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "_subtopics_v_version_default_visualization" ADD CONSTRAINT "_subtopics_v_version_default_visualization_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_subtopics_v"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_subtopics_v" ADD CONSTRAINT "_subtopics_v_parent_id_subtopics_id_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."subtopics"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "_subtopics_v" ADD CONSTRAINT "_subtopics_v_version_topic_id_topics_id_fk" FOREIGN KEY ("version_topic_id") REFERENCES "public"."topics"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "_subtopics_v_locales" ADD CONSTRAINT "_subtopics_v_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_subtopics_v"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "indicators_visualization_types" ADD CONSTRAINT "indicators_visualization_types_parent_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."indicators"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "indicators_blocks_feature_popup_template_field_infos" ADD CONSTRAINT "indicators_blocks_feature_popup_template_field_infos_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."indicators_blocks_feature"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "indicators_blocks_feature_popup_template_field_infos_locales" ADD CONSTRAINT "indicators_blocks_feature_popup_template_field_infos_loca_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."indicators_blocks_feature_popup_template_field_infos"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "indicators_blocks_feature" ADD CONSTRAINT "indicators_blocks_feature_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."indicators"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "indicators_blocks_imagery_legend_items" ADD CONSTRAINT "indicators_blocks_imagery_legend_items_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."indicators_blocks_imagery"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "indicators_blocks_imagery_legend_items_locales" ADD CONSTRAINT "indicators_blocks_imagery_legend_items_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."indicators_blocks_imagery_legend_items"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "indicators_blocks_imagery" ADD CONSTRAINT "indicators_blocks_imagery_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."indicators"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "indicators_blocks_imagery_tile_legend_items" ADD CONSTRAINT "indicators_blocks_imagery_tile_legend_items_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."indicators_blocks_imagery_tile"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "indicators_blocks_imagery_tile_legend_items_locales" ADD CONSTRAINT "indicators_blocks_imagery_tile_legend_items_locales_paren_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."indicators_blocks_imagery_tile_legend_items"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "indicators_blocks_imagery_tile" ADD CONSTRAINT "indicators_blocks_imagery_tile_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."indicators"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "indicators_blocks_web_tile" ADD CONSTRAINT "indicators_blocks_web_tile_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."indicators"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "indicators_blocks_h3" ADD CONSTRAINT "indicators_blocks_h3_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."indicators"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "indicators_blocks_component" ADD CONSTRAINT "indicators_blocks_component_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."indicators"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "indicators" ADD CONSTRAINT "indicators_subtopic_id_subtopics_id_fk" FOREIGN KEY ("subtopic_id") REFERENCES "public"."subtopics"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "indicators_locales" ADD CONSTRAINT "indicators_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."indicators"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_indicators_v_version_visualization_types" ADD CONSTRAINT "_indicators_v_version_visualization_types_parent_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."_indicators_v"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_indicators_v_blocks_feature_popup_template_field_infos" ADD CONSTRAINT "_indicators_v_blocks_feature_popup_template_field_infos_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_indicators_v_blocks_feature"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_indicators_v_blocks_feature_popup_template_field_infos_locales" ADD CONSTRAINT "_indicators_v_blocks_feature_popup_template_field_infos_l_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_indicators_v_blocks_feature_popup_template_field_infos"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_indicators_v_blocks_feature" ADD CONSTRAINT "_indicators_v_blocks_feature_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_indicators_v"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_indicators_v_blocks_imagery_legend_items" ADD CONSTRAINT "_indicators_v_blocks_imagery_legend_items_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_indicators_v_blocks_imagery"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_indicators_v_blocks_imagery_legend_items_locales" ADD CONSTRAINT "_indicators_v_blocks_imagery_legend_items_locales_parent__fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_indicators_v_blocks_imagery_legend_items"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_indicators_v_blocks_imagery" ADD CONSTRAINT "_indicators_v_blocks_imagery_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_indicators_v"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_indicators_v_blocks_imagery_tile_legend_items" ADD CONSTRAINT "_indicators_v_blocks_imagery_tile_legend_items_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_indicators_v_blocks_imagery_tile"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_indicators_v_blocks_imagery_tile_legend_items_locales" ADD CONSTRAINT "_indicators_v_blocks_imagery_tile_legend_items_locales_pa_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_indicators_v_blocks_imagery_tile_legend_items"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_indicators_v_blocks_imagery_tile" ADD CONSTRAINT "_indicators_v_blocks_imagery_tile_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_indicators_v"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_indicators_v_blocks_web_tile" ADD CONSTRAINT "_indicators_v_blocks_web_tile_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_indicators_v"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_indicators_v_blocks_h3" ADD CONSTRAINT "_indicators_v_blocks_h3_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_indicators_v"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_indicators_v_blocks_component" ADD CONSTRAINT "_indicators_v_blocks_component_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_indicators_v"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "_indicators_v" ADD CONSTRAINT "_indicators_v_parent_id_indicators_id_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."indicators"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "_indicators_v" ADD CONSTRAINT "_indicators_v_version_subtopic_id_subtopics_id_fk" FOREIGN KEY ("version_subtopic_id") REFERENCES "public"."subtopics"("id") ON DELETE set null ON UPDATE no action;
+  ALTER TABLE "_indicators_v_locales" ADD CONSTRAINT "_indicators_v_locales_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."_indicators_v"("id") ON DELETE cascade ON UPDATE no action;
+  CREATE INDEX "topics_default_visualization_order_idx" ON "topics_default_visualization" USING btree ("_order");
+  CREATE INDEX "topics_default_visualization_parent_id_idx" ON "topics_default_visualization" USING btree ("_parent_id");
+  CREATE INDEX "topics_default_visualization_indicator_idx" ON "topics_default_visualization" USING btree ("indicator_id");
+  CREATE UNIQUE INDEX "topics_legacy_id_idx" ON "topics" USING btree ("legacy_id");
+  CREATE INDEX "topics_updated_at_idx" ON "topics" USING btree ("updated_at");
+  CREATE INDEX "topics_created_at_idx" ON "topics" USING btree ("created_at");
+  CREATE INDEX "topics__status_idx" ON "topics" USING btree ("_status");
+  CREATE UNIQUE INDEX "topics_locales_locale_parent_id_unique" ON "topics_locales" USING btree ("_locale","_parent_id");
+  CREATE INDEX "_topics_v_version_default_visualization_order_idx" ON "_topics_v_version_default_visualization" USING btree ("_order");
+  CREATE INDEX "_topics_v_version_default_visualization_parent_id_idx" ON "_topics_v_version_default_visualization" USING btree ("_parent_id");
+  CREATE INDEX "_topics_v_version_default_visualization_indicator_idx" ON "_topics_v_version_default_visualization" USING btree ("indicator_id");
+  CREATE INDEX "_topics_v_parent_idx" ON "_topics_v" USING btree ("parent_id");
+  CREATE INDEX "_topics_v_version_version_legacy_id_idx" ON "_topics_v" USING btree ("version_legacy_id");
+  CREATE INDEX "_topics_v_version_version_updated_at_idx" ON "_topics_v" USING btree ("version_updated_at");
+  CREATE INDEX "_topics_v_version_version_created_at_idx" ON "_topics_v" USING btree ("version_created_at");
+  CREATE INDEX "_topics_v_version_version__status_idx" ON "_topics_v" USING btree ("version__status");
+  CREATE INDEX "_topics_v_created_at_idx" ON "_topics_v" USING btree ("created_at");
+  CREATE INDEX "_topics_v_updated_at_idx" ON "_topics_v" USING btree ("updated_at");
+  CREATE INDEX "_topics_v_snapshot_idx" ON "_topics_v" USING btree ("snapshot");
+  CREATE INDEX "_topics_v_published_locale_idx" ON "_topics_v" USING btree ("published_locale");
+  CREATE INDEX "_topics_v_latest_idx" ON "_topics_v" USING btree ("latest");
+  CREATE UNIQUE INDEX "_topics_v_locales_locale_parent_id_unique" ON "_topics_v_locales" USING btree ("_locale","_parent_id");
+  CREATE INDEX "subtopics_default_visualization_order_idx" ON "subtopics_default_visualization" USING btree ("_order");
+  CREATE INDEX "subtopics_default_visualization_parent_id_idx" ON "subtopics_default_visualization" USING btree ("_parent_id");
+  CREATE INDEX "subtopics_default_visualization_indicator_idx" ON "subtopics_default_visualization" USING btree ("indicator_id");
+  CREATE UNIQUE INDEX "subtopics_legacy_id_idx" ON "subtopics" USING btree ("legacy_id");
+  CREATE INDEX "subtopics_topic_idx" ON "subtopics" USING btree ("topic_id");
+  CREATE INDEX "subtopics_updated_at_idx" ON "subtopics" USING btree ("updated_at");
+  CREATE INDEX "subtopics_created_at_idx" ON "subtopics" USING btree ("created_at");
+  CREATE INDEX "subtopics__status_idx" ON "subtopics" USING btree ("_status");
+  CREATE UNIQUE INDEX "subtopics_locales_locale_parent_id_unique" ON "subtopics_locales" USING btree ("_locale","_parent_id");
+  CREATE INDEX "_subtopics_v_version_default_visualization_order_idx" ON "_subtopics_v_version_default_visualization" USING btree ("_order");
+  CREATE INDEX "_subtopics_v_version_default_visualization_parent_id_idx" ON "_subtopics_v_version_default_visualization" USING btree ("_parent_id");
+  CREATE INDEX "_subtopics_v_version_default_visualization_indicator_idx" ON "_subtopics_v_version_default_visualization" USING btree ("indicator_id");
+  CREATE INDEX "_subtopics_v_parent_idx" ON "_subtopics_v" USING btree ("parent_id");
+  CREATE INDEX "_subtopics_v_version_version_legacy_id_idx" ON "_subtopics_v" USING btree ("version_legacy_id");
+  CREATE INDEX "_subtopics_v_version_version_topic_idx" ON "_subtopics_v" USING btree ("version_topic_id");
+  CREATE INDEX "_subtopics_v_version_version_updated_at_idx" ON "_subtopics_v" USING btree ("version_updated_at");
+  CREATE INDEX "_subtopics_v_version_version_created_at_idx" ON "_subtopics_v" USING btree ("version_created_at");
+  CREATE INDEX "_subtopics_v_version_version__status_idx" ON "_subtopics_v" USING btree ("version__status");
+  CREATE INDEX "_subtopics_v_created_at_idx" ON "_subtopics_v" USING btree ("created_at");
+  CREATE INDEX "_subtopics_v_updated_at_idx" ON "_subtopics_v" USING btree ("updated_at");
+  CREATE INDEX "_subtopics_v_snapshot_idx" ON "_subtopics_v" USING btree ("snapshot");
+  CREATE INDEX "_subtopics_v_published_locale_idx" ON "_subtopics_v" USING btree ("published_locale");
+  CREATE INDEX "_subtopics_v_latest_idx" ON "_subtopics_v" USING btree ("latest");
+  CREATE UNIQUE INDEX "_subtopics_v_locales_locale_parent_id_unique" ON "_subtopics_v_locales" USING btree ("_locale","_parent_id");
+  CREATE INDEX "indicators_visualization_types_order_idx" ON "indicators_visualization_types" USING btree ("order");
+  CREATE INDEX "indicators_visualization_types_parent_idx" ON "indicators_visualization_types" USING btree ("parent_id");
+  CREATE INDEX "indicators_blocks_feature_popup_template_field_infos_order_idx" ON "indicators_blocks_feature_popup_template_field_infos" USING btree ("_order");
+  CREATE INDEX "indicators_blocks_feature_popup_template_field_infos_parent_id_idx" ON "indicators_blocks_feature_popup_template_field_infos" USING btree ("_parent_id");
+  CREATE UNIQUE INDEX "indicators_blocks_feature_popup_template_field_infos_local_1" ON "indicators_blocks_feature_popup_template_field_infos_locales" USING btree ("_locale","_parent_id");
+  CREATE INDEX "indicators_blocks_feature_order_idx" ON "indicators_blocks_feature" USING btree ("_order");
+  CREATE INDEX "indicators_blocks_feature_parent_id_idx" ON "indicators_blocks_feature" USING btree ("_parent_id");
+  CREATE INDEX "indicators_blocks_feature_path_idx" ON "indicators_blocks_feature" USING btree ("_path");
+  CREATE INDEX "indicators_blocks_imagery_legend_items_order_idx" ON "indicators_blocks_imagery_legend_items" USING btree ("_order");
+  CREATE INDEX "indicators_blocks_imagery_legend_items_parent_id_idx" ON "indicators_blocks_imagery_legend_items" USING btree ("_parent_id");
+  CREATE UNIQUE INDEX "indicators_blocks_imagery_legend_items_locales_locale_parent" ON "indicators_blocks_imagery_legend_items_locales" USING btree ("_locale","_parent_id");
+  CREATE INDEX "indicators_blocks_imagery_order_idx" ON "indicators_blocks_imagery" USING btree ("_order");
+  CREATE INDEX "indicators_blocks_imagery_parent_id_idx" ON "indicators_blocks_imagery" USING btree ("_parent_id");
+  CREATE INDEX "indicators_blocks_imagery_path_idx" ON "indicators_blocks_imagery" USING btree ("_path");
+  CREATE INDEX "indicators_blocks_imagery_tile_legend_items_order_idx" ON "indicators_blocks_imagery_tile_legend_items" USING btree ("_order");
+  CREATE INDEX "indicators_blocks_imagery_tile_legend_items_parent_id_idx" ON "indicators_blocks_imagery_tile_legend_items" USING btree ("_parent_id");
+  CREATE UNIQUE INDEX "indicators_blocks_imagery_tile_legend_items_locales_locale_p" ON "indicators_blocks_imagery_tile_legend_items_locales" USING btree ("_locale","_parent_id");
+  CREATE INDEX "indicators_blocks_imagery_tile_order_idx" ON "indicators_blocks_imagery_tile" USING btree ("_order");
+  CREATE INDEX "indicators_blocks_imagery_tile_parent_id_idx" ON "indicators_blocks_imagery_tile" USING btree ("_parent_id");
+  CREATE INDEX "indicators_blocks_imagery_tile_path_idx" ON "indicators_blocks_imagery_tile" USING btree ("_path");
+  CREATE INDEX "indicators_blocks_web_tile_order_idx" ON "indicators_blocks_web_tile" USING btree ("_order");
+  CREATE INDEX "indicators_blocks_web_tile_parent_id_idx" ON "indicators_blocks_web_tile" USING btree ("_parent_id");
+  CREATE INDEX "indicators_blocks_web_tile_path_idx" ON "indicators_blocks_web_tile" USING btree ("_path");
+  CREATE INDEX "indicators_blocks_h3_order_idx" ON "indicators_blocks_h3" USING btree ("_order");
+  CREATE INDEX "indicators_blocks_h3_parent_id_idx" ON "indicators_blocks_h3" USING btree ("_parent_id");
+  CREATE INDEX "indicators_blocks_h3_path_idx" ON "indicators_blocks_h3" USING btree ("_path");
+  CREATE INDEX "indicators_blocks_component_order_idx" ON "indicators_blocks_component" USING btree ("_order");
+  CREATE INDEX "indicators_blocks_component_parent_id_idx" ON "indicators_blocks_component" USING btree ("_parent_id");
+  CREATE INDEX "indicators_blocks_component_path_idx" ON "indicators_blocks_component" USING btree ("_path");
+  CREATE UNIQUE INDEX "indicators_legacy_id_idx" ON "indicators" USING btree ("legacy_id");
+  CREATE INDEX "indicators_subtopic_idx" ON "indicators" USING btree ("subtopic_id");
+  CREATE INDEX "indicators_updated_at_idx" ON "indicators" USING btree ("updated_at");
+  CREATE INDEX "indicators_created_at_idx" ON "indicators" USING btree ("created_at");
+  CREATE INDEX "indicators__status_idx" ON "indicators" USING btree ("_status");
+  CREATE UNIQUE INDEX "indicators_locales_locale_parent_id_unique" ON "indicators_locales" USING btree ("_locale","_parent_id");
+  CREATE INDEX "_indicators_v_version_visualization_types_order_idx" ON "_indicators_v_version_visualization_types" USING btree ("order");
+  CREATE INDEX "_indicators_v_version_visualization_types_parent_idx" ON "_indicators_v_version_visualization_types" USING btree ("parent_id");
+  CREATE INDEX "_indicators_v_blocks_feature_popup_template_field_infos_order_idx" ON "_indicators_v_blocks_feature_popup_template_field_infos" USING btree ("_order");
+  CREATE INDEX "_indicators_v_blocks_feature_popup_template_field_infos_parent_id_idx" ON "_indicators_v_blocks_feature_popup_template_field_infos" USING btree ("_parent_id");
+  CREATE UNIQUE INDEX "_indicators_v_blocks_feature_popup_template_field_infos_loca" ON "_indicators_v_blocks_feature_popup_template_field_infos_locales" USING btree ("_locale","_parent_id");
+  CREATE INDEX "_indicators_v_blocks_feature_order_idx" ON "_indicators_v_blocks_feature" USING btree ("_order");
+  CREATE INDEX "_indicators_v_blocks_feature_parent_id_idx" ON "_indicators_v_blocks_feature" USING btree ("_parent_id");
+  CREATE INDEX "_indicators_v_blocks_feature_path_idx" ON "_indicators_v_blocks_feature" USING btree ("_path");
+  CREATE INDEX "_indicators_v_blocks_imagery_legend_items_order_idx" ON "_indicators_v_blocks_imagery_legend_items" USING btree ("_order");
+  CREATE INDEX "_indicators_v_blocks_imagery_legend_items_parent_id_idx" ON "_indicators_v_blocks_imagery_legend_items" USING btree ("_parent_id");
+  CREATE UNIQUE INDEX "_indicators_v_blocks_imagery_legend_items_locales_locale_par" ON "_indicators_v_blocks_imagery_legend_items_locales" USING btree ("_locale","_parent_id");
+  CREATE INDEX "_indicators_v_blocks_imagery_order_idx" ON "_indicators_v_blocks_imagery" USING btree ("_order");
+  CREATE INDEX "_indicators_v_blocks_imagery_parent_id_idx" ON "_indicators_v_blocks_imagery" USING btree ("_parent_id");
+  CREATE INDEX "_indicators_v_blocks_imagery_path_idx" ON "_indicators_v_blocks_imagery" USING btree ("_path");
+  CREATE INDEX "_indicators_v_blocks_imagery_tile_legend_items_order_idx" ON "_indicators_v_blocks_imagery_tile_legend_items" USING btree ("_order");
+  CREATE INDEX "_indicators_v_blocks_imagery_tile_legend_items_parent_id_idx" ON "_indicators_v_blocks_imagery_tile_legend_items" USING btree ("_parent_id");
+  CREATE UNIQUE INDEX "_indicators_v_blocks_imagery_tile_legend_items_locales_local" ON "_indicators_v_blocks_imagery_tile_legend_items_locales" USING btree ("_locale","_parent_id");
+  CREATE INDEX "_indicators_v_blocks_imagery_tile_order_idx" ON "_indicators_v_blocks_imagery_tile" USING btree ("_order");
+  CREATE INDEX "_indicators_v_blocks_imagery_tile_parent_id_idx" ON "_indicators_v_blocks_imagery_tile" USING btree ("_parent_id");
+  CREATE INDEX "_indicators_v_blocks_imagery_tile_path_idx" ON "_indicators_v_blocks_imagery_tile" USING btree ("_path");
+  CREATE INDEX "_indicators_v_blocks_web_tile_order_idx" ON "_indicators_v_blocks_web_tile" USING btree ("_order");
+  CREATE INDEX "_indicators_v_blocks_web_tile_parent_id_idx" ON "_indicators_v_blocks_web_tile" USING btree ("_parent_id");
+  CREATE INDEX "_indicators_v_blocks_web_tile_path_idx" ON "_indicators_v_blocks_web_tile" USING btree ("_path");
+  CREATE INDEX "_indicators_v_blocks_h3_order_idx" ON "_indicators_v_blocks_h3" USING btree ("_order");
+  CREATE INDEX "_indicators_v_blocks_h3_parent_id_idx" ON "_indicators_v_blocks_h3" USING btree ("_parent_id");
+  CREATE INDEX "_indicators_v_blocks_h3_path_idx" ON "_indicators_v_blocks_h3" USING btree ("_path");
+  CREATE INDEX "_indicators_v_blocks_component_order_idx" ON "_indicators_v_blocks_component" USING btree ("_order");
+  CREATE INDEX "_indicators_v_blocks_component_parent_id_idx" ON "_indicators_v_blocks_component" USING btree ("_parent_id");
+  CREATE INDEX "_indicators_v_blocks_component_path_idx" ON "_indicators_v_blocks_component" USING btree ("_path");
+  CREATE INDEX "_indicators_v_parent_idx" ON "_indicators_v" USING btree ("parent_id");
+  CREATE INDEX "_indicators_v_version_version_legacy_id_idx" ON "_indicators_v" USING btree ("version_legacy_id");
+  CREATE INDEX "_indicators_v_version_version_subtopic_idx" ON "_indicators_v" USING btree ("version_subtopic_id");
+  CREATE INDEX "_indicators_v_version_version_updated_at_idx" ON "_indicators_v" USING btree ("version_updated_at");
+  CREATE INDEX "_indicators_v_version_version_created_at_idx" ON "_indicators_v" USING btree ("version_created_at");
+  CREATE INDEX "_indicators_v_version_version__status_idx" ON "_indicators_v" USING btree ("version__status");
+  CREATE INDEX "_indicators_v_created_at_idx" ON "_indicators_v" USING btree ("created_at");
+  CREATE INDEX "_indicators_v_updated_at_idx" ON "_indicators_v" USING btree ("updated_at");
+  CREATE INDEX "_indicators_v_snapshot_idx" ON "_indicators_v" USING btree ("snapshot");
+  CREATE INDEX "_indicators_v_published_locale_idx" ON "_indicators_v" USING btree ("published_locale");
+  CREATE INDEX "_indicators_v_latest_idx" ON "_indicators_v" USING btree ("latest");
+  CREATE UNIQUE INDEX "_indicators_v_locales_locale_parent_id_unique" ON "_indicators_v_locales" USING btree ("_locale","_parent_id");
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_topics_fk" FOREIGN KEY ("topics_id") REFERENCES "public"."topics"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_subtopics_fk" FOREIGN KEY ("subtopics_id") REFERENCES "public"."subtopics"("id") ON DELETE cascade ON UPDATE no action;
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_indicators_fk" FOREIGN KEY ("indicators_id") REFERENCES "public"."indicators"("id") ON DELETE cascade ON UPDATE no action;
+  CREATE INDEX "payload_locked_documents_rels_topics_id_idx" ON "payload_locked_documents_rels" USING btree ("topics_id");
+  CREATE INDEX "payload_locked_documents_rels_subtopics_id_idx" ON "payload_locked_documents_rels" USING btree ("subtopics_id");
+  CREATE INDEX "payload_locked_documents_rels_indicators_id_idx" ON "payload_locked_documents_rels" USING btree ("indicators_id");`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "topics_default_visualization" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "topics" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "topics_locales" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_topics_v_version_default_visualization" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_topics_v" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_topics_v_locales" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "subtopics_default_visualization" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "subtopics" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "subtopics_locales" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_subtopics_v_version_default_visualization" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_subtopics_v" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_subtopics_v_locales" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "indicators_visualization_types" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "indicators_blocks_feature_popup_template_field_infos" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "indicators_blocks_feature_popup_template_field_infos_locales" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "indicators_blocks_feature" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "indicators_blocks_imagery_legend_items" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "indicators_blocks_imagery_legend_items_locales" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "indicators_blocks_imagery" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "indicators_blocks_imagery_tile_legend_items" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "indicators_blocks_imagery_tile_legend_items_locales" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "indicators_blocks_imagery_tile" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "indicators_blocks_web_tile" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "indicators_blocks_h3" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "indicators_blocks_component" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "indicators" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "indicators_locales" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_indicators_v_version_visualization_types" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_indicators_v_blocks_feature_popup_template_field_infos" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_indicators_v_blocks_feature_popup_template_field_infos_locales" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_indicators_v_blocks_feature" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_indicators_v_blocks_imagery_legend_items" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_indicators_v_blocks_imagery_legend_items_locales" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_indicators_v_blocks_imagery" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_indicators_v_blocks_imagery_tile_legend_items" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_indicators_v_blocks_imagery_tile_legend_items_locales" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_indicators_v_blocks_imagery_tile" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_indicators_v_blocks_web_tile" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_indicators_v_blocks_h3" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_indicators_v_blocks_component" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_indicators_v" DISABLE ROW LEVEL SECURITY;
+  ALTER TABLE "_indicators_v_locales" DISABLE ROW LEVEL SECURITY;
+  DROP TABLE "topics_default_visualization" CASCADE;
+  DROP TABLE "topics" CASCADE;
+  DROP TABLE "topics_locales" CASCADE;
+  DROP TABLE "_topics_v_version_default_visualization" CASCADE;
+  DROP TABLE "_topics_v" CASCADE;
+  DROP TABLE "_topics_v_locales" CASCADE;
+  DROP TABLE "subtopics_default_visualization" CASCADE;
+  DROP TABLE "subtopics" CASCADE;
+  DROP TABLE "subtopics_locales" CASCADE;
+  DROP TABLE "_subtopics_v_version_default_visualization" CASCADE;
+  DROP TABLE "_subtopics_v" CASCADE;
+  DROP TABLE "_subtopics_v_locales" CASCADE;
+  DROP TABLE "indicators_visualization_types" CASCADE;
+  DROP TABLE "indicators_blocks_feature_popup_template_field_infos" CASCADE;
+  DROP TABLE "indicators_blocks_feature_popup_template_field_infos_locales" CASCADE;
+  DROP TABLE "indicators_blocks_feature" CASCADE;
+  DROP TABLE "indicators_blocks_imagery_legend_items" CASCADE;
+  DROP TABLE "indicators_blocks_imagery_legend_items_locales" CASCADE;
+  DROP TABLE "indicators_blocks_imagery" CASCADE;
+  DROP TABLE "indicators_blocks_imagery_tile_legend_items" CASCADE;
+  DROP TABLE "indicators_blocks_imagery_tile_legend_items_locales" CASCADE;
+  DROP TABLE "indicators_blocks_imagery_tile" CASCADE;
+  DROP TABLE "indicators_blocks_web_tile" CASCADE;
+  DROP TABLE "indicators_blocks_h3" CASCADE;
+  DROP TABLE "indicators_blocks_component" CASCADE;
+  DROP TABLE "indicators" CASCADE;
+  DROP TABLE "indicators_locales" CASCADE;
+  DROP TABLE "_indicators_v_version_visualization_types" CASCADE;
+  DROP TABLE "_indicators_v_blocks_feature_popup_template_field_infos" CASCADE;
+  DROP TABLE "_indicators_v_blocks_feature_popup_template_field_infos_locales" CASCADE;
+  DROP TABLE "_indicators_v_blocks_feature" CASCADE;
+  DROP TABLE "_indicators_v_blocks_imagery_legend_items" CASCADE;
+  DROP TABLE "_indicators_v_blocks_imagery_legend_items_locales" CASCADE;
+  DROP TABLE "_indicators_v_blocks_imagery" CASCADE;
+  DROP TABLE "_indicators_v_blocks_imagery_tile_legend_items" CASCADE;
+  DROP TABLE "_indicators_v_blocks_imagery_tile_legend_items_locales" CASCADE;
+  DROP TABLE "_indicators_v_blocks_imagery_tile" CASCADE;
+  DROP TABLE "_indicators_v_blocks_web_tile" CASCADE;
+  DROP TABLE "_indicators_v_blocks_h3" CASCADE;
+  DROP TABLE "_indicators_v_blocks_component" CASCADE;
+  DROP TABLE "_indicators_v" CASCADE;
+  DROP TABLE "_indicators_v_locales" CASCADE;
+  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_topics_fk";
+  
+  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_subtopics_fk";
+  
+  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_indicators_fk";
+  
+  ALTER TABLE "payload_jobs_log" ALTER COLUMN "task_slug" SET DATA TYPE text;
+  DROP TYPE "public"."enum_payload_jobs_log_task_slug";
+  CREATE TYPE "public"."enum_payload_jobs_log_task_slug" AS ENUM('inline', 'CleanAnonymousUsers');
+  ALTER TABLE "payload_jobs_log" ALTER COLUMN "task_slug" SET DATA TYPE "public"."enum_payload_jobs_log_task_slug" USING "task_slug"::"public"."enum_payload_jobs_log_task_slug";
+  ALTER TABLE "payload_jobs" ALTER COLUMN "task_slug" SET DATA TYPE text;
+  DROP TYPE "public"."enum_payload_jobs_task_slug";
+  CREATE TYPE "public"."enum_payload_jobs_task_slug" AS ENUM('inline', 'CleanAnonymousUsers');
+  ALTER TABLE "payload_jobs" ALTER COLUMN "task_slug" SET DATA TYPE "public"."enum_payload_jobs_task_slug" USING "task_slug"::"public"."enum_payload_jobs_task_slug";
+  DROP INDEX "payload_locked_documents_rels_topics_id_idx";
+  DROP INDEX "payload_locked_documents_rels_subtopics_id_idx";
+  DROP INDEX "payload_locked_documents_rels_indicators_id_idx";
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN "topics_id";
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN "subtopics_id";
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN "indicators_id";
+  DROP TYPE "public"."enum_topics_default_visualization_type";
+  DROP TYPE "public"."enum_topics_default_visualization_basemap_id";
+  DROP TYPE "public"."enum_topics_status";
+  DROP TYPE "public"."enum__topics_v_version_default_visualization_type";
+  DROP TYPE "public"."enum__topics_v_version_default_visualization_basemap_id";
+  DROP TYPE "public"."enum__topics_v_version_status";
+  DROP TYPE "public"."enum__topics_v_published_locale";
+  DROP TYPE "public"."enum_subtopics_default_visualization_type";
+  DROP TYPE "public"."enum_subtopics_default_visualization_basemap_id";
+  DROP TYPE "public"."enum_subtopics_status";
+  DROP TYPE "public"."enum__subtopics_v_version_default_visualization_type";
+  DROP TYPE "public"."enum__subtopics_v_version_default_visualization_basemap_id";
+  DROP TYPE "public"."enum__subtopics_v_version_status";
+  DROP TYPE "public"."enum__subtopics_v_published_locale";
+  DROP TYPE "public"."enum_indicators_visualization_types";
+  DROP TYPE "public"."enum_indicators_blocks_imagery_legend_type";
+  DROP TYPE "public"."enum_indicators_blocks_imagery_tile_legend_type";
+  DROP TYPE "public"."enum_indicators_status";
+  DROP TYPE "public"."enum__indicators_v_version_visualization_types";
+  DROP TYPE "public"."enum__indicators_v_blocks_imagery_legend_type";
+  DROP TYPE "public"."enum__indicators_v_blocks_imagery_tile_legend_type";
+  DROP TYPE "public"."enum__indicators_v_version_status";
+  DROP TYPE "public"."enum__indicators_v_published_locale";`)
+}

--- a/client/src/cms/migrations/index.ts
+++ b/client/src/cms/migrations/index.ts
@@ -1,5 +1,6 @@
 import * as migration_20251202_124844 from './20251202_124844';
 import * as migration_20260210_161015 from './20260210_161015';
+import * as migration_20260803_090559 from './20260803_090559';
 
 export const migrations = [
   {
@@ -10,6 +11,11 @@ export const migrations = [
   {
     up: migration_20260210_161015.up,
     down: migration_20260210_161015.down,
-    name: '20260210_161015'
+    name: '20260210_161015',
+  },
+  {
+    up: migration_20260803_090559.up,
+    down: migration_20260803_090559.down,
+    name: '20260803_090559'
   },
 ];

--- a/client/src/cms/test-utils/find-field.ts
+++ b/client/src/cms/test-utils/find-field.ts
@@ -1,0 +1,35 @@
+import type { Field, NonPresentationalField } from "payload";
+
+/**
+ * Any field that has a `name` — i.e. everything except layout fields (row, collapsible,
+ * tabs). `FieldBase` gives all of these `required`, `localized`, `unique`, `index` and
+ * `access`, so those read directly off the union with no cast.
+ *
+ * Starts from `NonPresentationalField` (Payload's own "everything but UI fields" union),
+ * not `Field` directly: Payload's `UIField` has a `name` of its own but doesn't extend
+ * `FieldBase`, so `Extract<Field, { name: string }>` would structurally admit it too —
+ * and then `.required` wouldn't exist on the union. `RESOURCE_BLOCKS` never uses a `ui`
+ * field, so excluding it here costs nothing.
+ *
+ * Type-specific properties (`options`, `hasMany`, `relationTo`, `minRows`) still need a
+ * narrowing cast to the concrete field type at the point of use. Keep it that way — a
+ * widened `any`-ish shape here would silently accept a wrong field name or type.
+ */
+export type NamedField = Extract<NonPresentationalField, { name: string }>;
+
+const hasName = (field: Field): field is NamedField => "name" in field && field.type !== "ui";
+
+export const namedFields = (fields: Field[]): NamedField[] => fields.filter(hasName);
+
+export const findFieldByName = (fields: Field[], name: string): NamedField | undefined =>
+  namedFields(fields).find((field) => field.name === name);
+
+export const fieldNames = (fields: Field[]): string[] =>
+  namedFields(fields).map((field) => field.name);
+
+/** Treats the source JSON's `""` / `[]` / null sentinels as absent. */
+export const isEmptyValue = (value: unknown): boolean =>
+  value === null ||
+  value === undefined ||
+  value === "" ||
+  (Array.isArray(value) && value.length === 0);

--- a/client/src/payload-types.ts
+++ b/client/src/payload-types.ts
@@ -75,6 +75,9 @@ export interface Config {
     accounts: Account;
     media: Media;
     reports: Report;
+    topics: Topic;
+    subtopics: Subtopic;
+    indicators: Indicator;
     'payload-kv': PayloadKv;
     'payload-jobs': PayloadJob;
     'payload-locked-documents': PayloadLockedDocument;
@@ -94,6 +97,9 @@ export interface Config {
     accounts: AccountsSelect<false> | AccountsSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     reports: ReportsSelect<false> | ReportsSelect<true>;
+    topics: TopicsSelect<false> | TopicsSelect<true>;
+    subtopics: SubtopicsSelect<false> | SubtopicsSelect<true>;
+    indicators: IndicatorsSelect<false> | IndicatorsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-jobs': PayloadJobsSelect<false> | PayloadJobsSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -358,6 +364,330 @@ export interface Media {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "topics".
+ */
+export interface Topic {
+  id: string;
+  /**
+   * Numeric id from the original datum JSON. Referenced by existing reports rows and by the defaultTopics URL param. Never change it.
+   */
+  legacy_id: number;
+  name: string;
+  /**
+   * Markdown. Rendered with react-markdown.
+   */
+  description?: string | null;
+  /**
+   * Path under client/public, e.g. /images/topics/territory.webp
+   */
+  image?: string | null;
+  default_visualization?:
+    | {
+        indicator: string | Indicator;
+        /**
+         * The source data only uses map, numeric, chart and table; custom and ai exist to match Reports.
+         */
+        type: 'map' | 'chart' | 'table' | 'numeric' | 'custom' | 'ai';
+        x: number;
+        y: number;
+        w: number;
+        h: number;
+        basemapId?:
+          | (
+              | 'gray-vector'
+              | 'dark-gray-vector'
+              | 'satellite'
+              | 'streets'
+              | 'hybrid'
+              | 'osm'
+              | 'topo-vector'
+              | 'terrain'
+            )
+          | null;
+        opacity?: number | null;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "indicators".
+ */
+export interface Indicator {
+  id: string;
+  /**
+   * Numeric id from the original datum JSON. Referenced by existing reports rows and by the defaultTopics URL param. Never change it.
+   */
+  legacy_id: number;
+  /**
+   * Display order within a subtopic. Not the same as legacy_id — they diverge on some rows.
+   */
+  order: number;
+  subtopic: string | Subtopic;
+  name: string;
+  /**
+   * e.g. km², m. Empty on 63 of 164 rows.
+   */
+  unit?: string | null;
+  description_short: string;
+  /**
+   * Markdown. Rendered with react-markdown in containers/info.
+   */
+  description?: string | null;
+  /**
+   * Which widgets this indicator offers. Deliberately explicit, not derived: deriving would change 18 of 164 rows. Empty for all h3 indicators.
+   */
+  visualization_types?: ('map' | 'table' | 'chart' | 'numeric')[] | null;
+  /**
+   * Exactly one resource. The block type is the resource type.
+   */
+  resource: (
+    | {
+        /**
+         * Display/machine name. Empty on 14 source rows; not read by any code for this resource type.
+         */
+        name?: string | null;
+        url: string;
+        /**
+         * Text, not a number: lib/indicators.ts builds the layer URL as `url + layer_id`.
+         */
+        layer_id: string;
+        /**
+         * Rebuilt on read as { title, content: [{ type: 'fields', fieldInfos }] } — the only content shape present in the source data.
+         */
+        popupTemplate?: {
+          title?: string | null;
+          fieldInfos?:
+            | {
+                fieldName: string;
+                label: string;
+                id?: string | null;
+              }[]
+            | null;
+        };
+        /**
+         * ArcGIS __esri.QueryProperties, passed unmodified to `new Query()`.
+         */
+        query_numeric?:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        /**
+         * ArcGIS __esri.QueryProperties, passed unmodified to `new Query()`.
+         */
+        query_table?:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        /**
+         * ArcGIS __esri.QueryProperties, passed unmodified to `new Query()`.
+         */
+        query_chart?:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        /**
+         * ArcGIS __esri.QueryProperties, passed unmodified to `new Query()`.
+         */
+        query_ai?:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'feature';
+      }
+    | {
+        /**
+         * Display/machine name. Empty on 14 source rows; not read by any code for this resource type.
+         */
+        name?: string | null;
+        url: string;
+        /**
+         * ArcGIS __esri.RasterFunctionProperties, e.g. a Colormap function.
+         */
+        rasterFunction:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        legend: {
+          type: 'basic';
+          items: {
+            label: string;
+            /**
+             * Hex, e.g. #EEF0BA
+             */
+            color: string;
+            id?: string | null;
+          }[];
+        };
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'imagery';
+      }
+    | {
+        /**
+         * Display/machine name. Empty on 14 source rows; not read by any code for this resource type.
+         */
+        name?: string | null;
+        url: string;
+        /**
+         * ArcGIS __esri.RasterFunctionProperties, e.g. a Colormap function.
+         */
+        rasterFunction:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        legend: {
+          type: 'basic';
+          items: {
+            label: string;
+            /**
+             * Hex, e.g. #EEF0BA
+             */
+            color: string;
+            id?: string | null;
+          }[];
+        };
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'imagery-tile';
+      }
+    | {
+        /**
+         * Display/machine name. Empty on 14 source rows; not read by any code for this resource type.
+         */
+        name?: string | null;
+        url: string;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'web-tile';
+      }
+    | {
+        /**
+         * Machine name. Keys the COMPONENT_INDICATORS registry in containers/indicators/custom/index.tsx (`total-area`, `AMZ_LOCADM2`) — do not rename without checking that file.
+         */
+        name: string;
+        /**
+         * H3 variable name, matched against META.datasets[].var_name.
+         */
+        column: string;
+        url?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'h3';
+      }
+    | {
+        /**
+         * Machine name. Keys the COMPONENT_INDICATORS registry in containers/indicators/custom/index.tsx (`total-area`, `AMZ_LOCADM2`) — do not rename without checking that file.
+         */
+        name: string;
+        /**
+         * ArcGIS __esri.QueryProperties, passed unmodified to `new Query()`.
+         */
+        query_ai?:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'component';
+      }
+  )[];
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "subtopics".
+ */
+export interface Subtopic {
+  id: string;
+  /**
+   * Numeric id from the original datum JSON. Referenced by existing reports rows and by the defaultTopics URL param. Never change it.
+   */
+  legacy_id: number;
+  topic: string | Topic;
+  /**
+   * English only in the source data. ES and PT translations are seeded in phase 2; reads fall back to en until then.
+   */
+  name: string;
+  /**
+   * Markdown. Empty on every row in the source data.
+   */
+  description?: string | null;
+  default_visualization?:
+    | {
+        indicator: string | Indicator;
+        /**
+         * The source data only uses map, numeric, chart and table; custom and ai exist to match Reports.
+         */
+        type: 'map' | 'chart' | 'table' | 'numeric' | 'custom' | 'ai';
+        x: number;
+        y: number;
+        w: number;
+        h: number;
+        basemapId?:
+          | (
+              | 'gray-vector'
+              | 'dark-gray-vector'
+              | 'satellite'
+              | 'streets'
+              | 'hybrid'
+              | 'osm'
+              | 'topo-vector'
+              | 'terrain'
+            )
+          | null;
+        opacity?: number | null;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -504,6 +834,18 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'reports';
         value: string | Report;
+      } | null)
+    | ({
+        relationTo: 'topics';
+        value: string | Topic;
+      } | null)
+    | ({
+        relationTo: 'subtopics';
+        value: string | Subtopic;
+      } | null)
+    | ({
+        relationTo: 'indicators';
+        value: string | Indicator;
       } | null);
   globalSlug?: string | null;
   user:
@@ -684,6 +1026,171 @@ export interface ReportsSelect<T extends boolean = true> {
               id?: T;
             };
         id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "topics_select".
+ */
+export interface TopicsSelect<T extends boolean = true> {
+  legacy_id?: T;
+  name?: T;
+  description?: T;
+  image?: T;
+  default_visualization?:
+    | T
+    | {
+        indicator?: T;
+        type?: T;
+        x?: T;
+        y?: T;
+        w?: T;
+        h?: T;
+        basemapId?: T;
+        opacity?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "subtopics_select".
+ */
+export interface SubtopicsSelect<T extends boolean = true> {
+  legacy_id?: T;
+  topic?: T;
+  name?: T;
+  description?: T;
+  default_visualization?:
+    | T
+    | {
+        indicator?: T;
+        type?: T;
+        x?: T;
+        y?: T;
+        w?: T;
+        h?: T;
+        basemapId?: T;
+        opacity?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "indicators_select".
+ */
+export interface IndicatorsSelect<T extends boolean = true> {
+  legacy_id?: T;
+  order?: T;
+  subtopic?: T;
+  name?: T;
+  unit?: T;
+  description_short?: T;
+  description?: T;
+  visualization_types?: T;
+  resource?:
+    | T
+    | {
+        feature?:
+          | T
+          | {
+              name?: T;
+              url?: T;
+              layer_id?: T;
+              popupTemplate?:
+                | T
+                | {
+                    title?: T;
+                    fieldInfos?:
+                      | T
+                      | {
+                          fieldName?: T;
+                          label?: T;
+                          id?: T;
+                        };
+                  };
+              query_numeric?: T;
+              query_table?: T;
+              query_chart?: T;
+              query_ai?: T;
+              id?: T;
+              blockName?: T;
+            };
+        imagery?:
+          | T
+          | {
+              name?: T;
+              url?: T;
+              rasterFunction?: T;
+              legend?:
+                | T
+                | {
+                    type?: T;
+                    items?:
+                      | T
+                      | {
+                          label?: T;
+                          color?: T;
+                          id?: T;
+                        };
+                  };
+              id?: T;
+              blockName?: T;
+            };
+        'imagery-tile'?:
+          | T
+          | {
+              name?: T;
+              url?: T;
+              rasterFunction?: T;
+              legend?:
+                | T
+                | {
+                    type?: T;
+                    items?:
+                      | T
+                      | {
+                          label?: T;
+                          color?: T;
+                          id?: T;
+                        };
+                  };
+              id?: T;
+              blockName?: T;
+            };
+        'web-tile'?:
+          | T
+          | {
+              name?: T;
+              url?: T;
+              id?: T;
+              blockName?: T;
+            };
+        h3?:
+          | T
+          | {
+              name?: T;
+              column?: T;
+              url?: T;
+              id?: T;
+              blockName?: T;
+            };
+        component?:
+          | T
+          | {
+              name?: T;
+              query_ai?: T;
+              id?: T;
+              blockName?: T;
+            };
       };
   updatedAt?: T;
   createdAt?: T;

--- a/client/src/payload.config.ts
+++ b/client/src/payload.config.ts
@@ -18,8 +18,11 @@ import { env } from "@/env.mjs";
 import { Accounts } from "@/cms/collections/Accounts";
 import { Admins } from "@/cms/collections/Admins";
 import { AnonymousUsers } from "@/cms/collections/AnonymousUsers";
+import { Indicators } from "@/cms/collections/Indicators";
 import { Media } from "@/cms/collections/Media";
 import { Reports } from "@/cms/collections/Reports";
+import { Subtopics } from "@/cms/collections/Subtopics";
+import { Topics } from "@/cms/collections/Topics";
 import { Users } from "@/cms/collections/Users";
 import { CleanAnonymousUsers } from "@/cms/cron/clean-anonymous-users";
 import { CleanDraftReports } from "@/cms/cron/clean-draft-reports";
@@ -58,7 +61,17 @@ export default buildConfig({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Admins, Users, AnonymousUsers, Accounts, Media, Reports],
+  collections: [
+    Admins,
+    Users,
+    AnonymousUsers,
+    Accounts,
+    Media,
+    Reports,
+    Topics,
+    Subtopics,
+    Indicators,
+  ],
   db: postgresAdapter({
     idType: "uuid",
     pool: {


### PR DESCRIPTION
## Summary

Phase 1 of moving `client/datum/{topics,subtopics,indicators}.json` into Payload CMS. Adds three collections (`Topics`, `Subtopics`, `Indicators`) sharing two extracted field modules — a `default_visualization` array and a discriminated `resource` blocks field — plus a non-blocking `beforeChange` hook that warns on indicator visualization/query mismatches.

- **`*_en/_es/_pt` triples collapse into Payload's native `localized` fields.** The original numeric ids survive as an immutable `legacy_id` (`access: { update: () => false }`, not `admin.readOnly`, so phase 2 can still seed it) because the untouched `reports` table and the `defaultTopics` URL param still reference them.
- **Tables ship empty.** The JSONs remain the source of truth until phase 2. 55 conformance tests assert the schema can hold all 201 existing rows (164 indicators + 28 subtopics + 9 topics) losslessly, running against the real `datum/*.json` rather than fixtures.
- **Two documented data defects are allowlisted** and self-policing: subtopic 26 → nonexistent indicator 55, and indicator 12's stray `rasterFunction`. A third violation fails the suite rather than passing silently.

## Test plan

- [x] `pnpm lint` — 0 errors (10 pre-existing `@ts-nocheck` warnings also present on `develop`)
- [x] `pnpm check-types` — 0 errors
- [x] `pnpm test` — 25 files / 225 tests passing
- [x] Pre-commit hook (`lint --fix && check-types && test`) passes without `--no-verify`
- [x] Migration `up()` verified purely additive — zero `DROP TABLE`/`DROP COLUMN`/`DROP CONSTRAINT`/`ALTER COLUMN` against any pre-existing table; the only one touched is `payload_locked_documents_rels` (`ADD COLUMN` + FKs, standard Payload bookkeeping)
- [ ] Migration applied to a real database
- [ ] Admin UI checklist above