### PR TITLE
feat(client): seed datum catalogue into CMS as published multi-locale docs

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report e2e/playwright-report",
     "payload": "payload",
-    "seed:catalogue": "payload run scripts/seed-catalogue.ts",
+    "seed:catalogue": "payload run scripts/seed-catalogue.ts --",
     "ci": "payload migrate && pnpm build"
   },
   "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "test:e2e:report": "playwright show-report e2e/playwright-report",
     "payload": "payload",
     "seed:catalogue": "payload run scripts/seed-catalogue.ts --",
+    "verify:catalogue": "payload run scripts/verify-catalogue.ts --",
     "ci": "payload migrate && pnpm build"
   },
   "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report e2e/playwright-report",
     "payload": "payload",
+    "seed:catalogue": "payload run scripts/seed-catalogue.ts",
     "ci": "payload migrate && pnpm build"
   },
   "dependencies": {

--- a/client/scripts/seed-catalogue.ts
+++ b/client/scripts/seed-catalogue.ts
@@ -1,0 +1,249 @@
+// client/scripts/seed-catalogue.ts
+/* eslint-disable no-console */
+import { getPayload, type Payload, type PayloadRequest } from "payload";
+
+import config from "@payload-config";
+
+import { describeAppliedFixes } from "@/cms/seed/fixes";
+import { mapDefaultVisualization } from "@/cms/seed/map-default-visualization";
+import { mapIndicatorBase, mapIndicatorLocale } from "@/cms/seed/map-indicator";
+import { mapSubtopicBase, mapSubtopicLocale } from "@/cms/seed/map-subtopic";
+import { mapTopicBase, mapTopicLocale } from "@/cms/seed/map-topic";
+import {
+  rawIndicators,
+  rawSubtopics,
+  rawTopics,
+  TRANSLATION_LOCALES,
+  type Locale,
+} from "@/cms/seed/source";
+
+type CatalogueSlug = "topics" | "subtopics" | "indicators";
+
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has("--dry-run");
+const overwrite = args.has("--overwrite");
+
+/** Documents this run created, per collection — pass 4 only backfills these. */
+const created = {
+  topics: new Set<number>(),
+  subtopics: new Set<number>(),
+  indicators: new Set<number>(),
+};
+const counts = {
+  topics: { created: 0, updated: 0, skipped: 0 },
+  subtopics: { created: 0, updated: 0, skipped: 0 },
+  indicators: { created: 0, updated: 0, skipped: 0 },
+};
+
+async function findByLegacyId(
+  payload: Payload,
+  collection: CatalogueSlug,
+  legacyId: number,
+  req: Partial<PayloadRequest>,
+): Promise<string | undefined> {
+  const { docs } = await payload.find({
+    collection,
+    where: { legacy_id: { equals: legacyId } },
+    limit: 1,
+    depth: 0,
+    pagination: false,
+    draft: true,
+    req,
+  });
+  return docs[0]?.id as string | undefined;
+}
+
+/**
+ * Writes one document as published in `en`, then translates it. Returns the document id, or
+ * undefined when an existing row is left alone in create-only mode.
+ */
+async function upsert(
+  payload: Payload,
+  collection: CatalogueSlug,
+  legacyId: number,
+  base: Record<string, unknown>,
+  locales: Partial<Record<Locale, Record<string, unknown>>>,
+  req: Partial<PayloadRequest>,
+): Promise<string | undefined> {
+  const existing = await findByLegacyId(payload, collection, legacyId, req);
+
+  if (existing && !overwrite) {
+    counts[collection].skipped += 1;
+    return existing;
+  }
+
+  let id: string;
+  if (existing) {
+    const doc = await payload.update({
+      collection,
+      id: existing,
+      data: base,
+      locale: "en",
+      draft: false,
+      req,
+    });
+    id = doc.id as string;
+    counts[collection].updated += 1;
+  } else {
+    const doc = await payload.create({
+      collection,
+      data: base as never,
+      locale: "en",
+      draft: false,
+      req,
+    });
+    id = doc.id as string;
+    counts[collection].created += 1;
+    created[collection].add(legacyId);
+  }
+
+  for (const locale of TRANSLATION_LOCALES) {
+    const data = locales[locale];
+    if (!data || Object.keys(data).length === 0) continue;
+    await payload.update({ collection, id, data, locale, draft: false, req });
+  }
+
+  return id;
+}
+
+/** Reads every legacy_id -> uuid pair from the database, so partial states still resolve. */
+async function idMap(
+  payload: Payload,
+  collection: CatalogueSlug,
+  req: Partial<PayloadRequest>,
+): Promise<Map<number, string>> {
+  const { docs } = await payload.find({
+    collection,
+    limit: 0,
+    pagination: false,
+    depth: 0,
+    draft: true,
+    req,
+  });
+  return new Map(docs.map((d) => [d.legacy_id as number, d.id as string]));
+}
+
+async function seed(payload: Payload, req: Partial<PayloadRequest>) {
+  // Pass 1 — topics, without default_visualization
+  for (const row of rawTopics) {
+    await upsert(
+      payload,
+      "topics",
+      row.id,
+      mapTopicBase(row),
+      { es: mapTopicLocale(row, "es"), pt: mapTopicLocale(row, "pt") },
+      req,
+    );
+  }
+  console.log(`  topics      ${summary("topics")}`);
+
+  // Pass 2 — subtopics
+  const topicIds = await idMap(payload, "topics", req);
+  for (const row of rawSubtopics) {
+    await upsert(
+      payload,
+      "subtopics",
+      row.id,
+      mapSubtopicBase(row, topicIds),
+      { es: mapSubtopicLocale(row, "es"), pt: mapSubtopicLocale(row, "pt") },
+      req,
+    );
+  }
+  console.log(`  subtopics   ${summary("subtopics")}`);
+
+  // Pass 3 — indicators
+  const subtopicIds = await idMap(payload, "subtopics", req);
+  for (const row of rawIndicators) {
+    await upsert(
+      payload,
+      "indicators",
+      row.id,
+      mapIndicatorBase(row, subtopicIds),
+      { es: mapIndicatorLocale(row, "es"), pt: mapIndicatorLocale(row, "pt") },
+      req,
+    );
+  }
+  console.log(`  indicators  ${summary("indicators")}`);
+
+  // Pass 4 — backfill default_visualization
+  const indicatorIds = await idMap(payload, "indicators", req);
+  let backfilled = 0;
+
+  for (const [collection, rows] of [
+    ["topics", rawTopics],
+    ["subtopics", rawSubtopics],
+  ] as const) {
+    const ids = collection === "topics" ? topicIds : await idMap(payload, collection, req);
+
+    for (const row of rows) {
+      if (!row.default_visualization?.length) continue;
+      if (!overwrite && !created[collection].has(row.id)) continue;
+
+      const id = ids.get(row.id) ?? (await findByLegacyId(payload, collection, row.id, req));
+      if (!id) continue;
+
+      const { entries, skipped } = mapDefaultVisualization(
+        row.default_visualization,
+        row.id,
+        indicatorIds,
+      );
+      for (const missing of skipped) {
+        console.warn(
+          `  ⚠ skipped  ${collection} legacy_id=${row.id} default_visualization -> indicator ${missing} not found`,
+        );
+      }
+
+      await payload.update({
+        collection,
+        id,
+        data: { default_visualization: entries },
+        locale: "en",
+        draft: false,
+        req,
+      });
+      backfilled += 1;
+    }
+  }
+  console.log(`  backfill    default_visualization on ${backfilled} documents`);
+}
+
+function summary(collection: CatalogueSlug): string {
+  const c = counts[collection];
+  return `+${c.created} created  ~${c.updated} updated  ○${c.skipped} skipped`;
+}
+
+async function main() {
+  const payload = await getPayload({ config });
+  const mode = overwrite ? "overwrite" : "create-only";
+  console.log(`\nSeeding catalogue (${mode}${dryRun ? ", dry run" : ""})\n`);
+
+  for (const fix of describeAppliedFixes()) {
+    console.log(`  ⚙ fix       ${fix.collection} legacy_id=${fix.legacy_id}  ${fix.change}`);
+  }
+
+  const transactionID = await payload.db.beginTransaction();
+  if (!transactionID) throw new Error("could not begin a database transaction");
+  const req: Partial<PayloadRequest> = { transactionID };
+
+  try {
+    await seed(payload, req);
+  } catch (error) {
+    await payload.db.rollbackTransaction(transactionID);
+    throw error;
+  }
+
+  if (dryRun) {
+    await payload.db.rollbackTransaction(transactionID);
+    console.log("\n  ↩ dry run — transaction rolled back, nothing persisted\n");
+  } else {
+    await payload.db.commitTransaction(transactionID);
+    console.log("\n  ✅ committed\n");
+  }
+
+  await payload.destroy();
+}
+
+await main().catch((error) => {
+  console.error("\n  ❌ seed failed:", error);
+  process.exit(1);
+});

--- a/client/scripts/seed-catalogue.ts
+++ b/client/scripts/seed-catalogue.ts
@@ -1,6 +1,9 @@
-// client/scripts/seed-catalogue.ts
-/* eslint-disable no-console */
-import { getPayload, type Payload, type PayloadRequest } from "payload";
+import {
+  getPayload,
+  type Payload,
+  type PayloadRequest,
+  type RequiredDataFromCollectionSlug,
+} from "payload";
 
 import config from "@payload-config";
 
@@ -54,14 +57,15 @@ async function findByLegacyId(
 }
 
 /**
- * Writes one document as published in `en`, then translates it. Returns the document id, or
- * undefined when an existing row is left alone in create-only mode.
+ * Writes one document as published in `en`, then translates it. Returns the document id — the
+ * newly created/updated id, or the existing id when an existing row is left alone in
+ * create-only mode.
  */
-async function upsert(
+async function upsert<TSlug extends CatalogueSlug>(
   payload: Payload,
-  collection: CatalogueSlug,
+  collection: TSlug,
   legacyId: number,
-  base: Record<string, unknown>,
+  base: RequiredDataFromCollectionSlug<TSlug>,
   locales: Partial<Record<Locale, Record<string, unknown>>>,
   req: Partial<PayloadRequest>,
 ): Promise<string | undefined> {
@@ -72,12 +76,26 @@ async function upsert(
     return existing;
   }
 
+  // `_status` is not localized: setting it once on the `en` write is enough. `draft: false`
+  // alone does not publish — versions.drafts defaults `_status` to `draft` on create, and
+  // nothing else on the create path sets it to `published` unless localizeStatus is enabled
+  // (it is not, here).
+  const publishedBase = { ...base, _status: "published" as const };
+
   let id: string;
   if (existing) {
+    // `payload.update`'s data type is `DeepPartial<MarkOptional<DataFromCollectionSlug<TSlug>, ...>>`
+    // built through a nested generic composition that TypeScript cannot prove assignable for an
+    // abstract `TSlug` even though it holds for every concrete slug (verified: the identical
+    // assignment typechecks with a literal collection slug, only the generic-through-generic
+    // case fails) — see https://github.com/microsoft/TypeScript/issues/13995-style limitation.
+    // `payload.create` right below has no such issue and typechecks `publishedBase` against the
+    // real collection shape with no cast, which is what actually catches a mapper/collection
+    // mismatch; this cast only works around the `update` composition, not a real mismatch.
     const doc = await payload.update({
       collection,
       id: existing,
-      data: base,
+      data: publishedBase as never,
       locale: "en",
       draft: false,
       req,
@@ -87,7 +105,7 @@ async function upsert(
   } else {
     const doc = await payload.create({
       collection,
-      data: base as never,
+      data: publishedBase,
       locale: "en",
       draft: false,
       req,
@@ -100,7 +118,8 @@ async function upsert(
   for (const locale of TRANSLATION_LOCALES) {
     const data = locales[locale];
     if (!data || Object.keys(data).length === 0) continue;
-    await payload.update({ collection, id, data, locale, draft: false, req });
+    // Same `update` generic-composition limitation as above.
+    await payload.update({ collection, id, data: data as never, locale, draft: false, req });
   }
 
   return id;
@@ -120,7 +139,9 @@ async function idMap(
     draft: true,
     req,
   });
-  return new Map(docs.map((d) => [d.legacy_id as number, d.id as string]));
+  return new Map(
+    docs.filter((d) => d.legacy_id != null).map((d) => [d.legacy_id as number, d.id as string]),
+  );
 }
 
 async function seed(payload: Payload, req: Partial<PayloadRequest>) {
@@ -226,21 +247,29 @@ async function main() {
   const req: Partial<PayloadRequest> = { transactionID };
 
   try {
-    await seed(payload, req);
-  } catch (error) {
-    await payload.db.rollbackTransaction(transactionID);
-    throw error;
-  }
+    try {
+      await seed(payload, req);
+    } catch (error) {
+      try {
+        await payload.db.rollbackTransaction(transactionID);
+      } catch (rollbackError) {
+        console.error("\n  ❌ rollback also failed:", rollbackError);
+      }
+      // Always rethrow the original error — it carries the mapper's row-naming diagnostic,
+      // which matters far more than a rollback failure.
+      throw error;
+    }
 
-  if (dryRun) {
-    await payload.db.rollbackTransaction(transactionID);
-    console.log("\n  ↩ dry run — transaction rolled back, nothing persisted\n");
-  } else {
-    await payload.db.commitTransaction(transactionID);
-    console.log("\n  ✅ committed\n");
+    if (dryRun) {
+      await payload.db.rollbackTransaction(transactionID);
+      console.log("\n  ↩ dry run — transaction rolled back, nothing persisted\n");
+    } else {
+      await payload.db.commitTransaction(transactionID);
+      console.log("\n  ✅ committed\n");
+    }
+  } finally {
+    await payload.destroy();
   }
-
-  await payload.destroy();
 }
 
 await main().catch((error) => {

--- a/client/scripts/seed-catalogue.ts
+++ b/client/scripts/seed-catalogue.ts
@@ -22,6 +22,26 @@ import {
 
 type CatalogueSlug = "topics" | "subtopics" | "indicators";
 
+/**
+ * Fields copied from the `en` write into each translation write.
+ *
+ * Payload validates the *whole* document against the request locale on every update, and two
+ * subfields inside the indicator `resource` blocks — `popupTemplate.fieldInfos[].label` and
+ * `legend.items[].label` — are both `localized` and `required`. The block rows themselves are
+ * not localized, so they survive the `en` write, but their `label` values are empty in `es`
+ * and `pt`; a translation update that omits `resource` therefore fails validation on the 45
+ * indicators carrying popup field infos and the 27 carrying legend items.
+ *
+ * The source data has a single language for those labels — there is no `label_es`/`label_pt`
+ * anywhere in `datum/indicators.json` — so the blocks are sent back exactly as the `en` write
+ * returned them, ids included. That is what the admin UI itself does when a locale tab is
+ * saved, and it seeds the untranslated labels with the English text that locale fallback was
+ * already showing readers.
+ */
+const CARRIED_TO_TRANSLATIONS: Partial<Record<CatalogueSlug, readonly string[]>> = {
+  indicators: ["resource"],
+};
+
 const args = new Set(process.argv.slice(2));
 const dryRun = args.has("--dry-run");
 const overwrite = args.has("--overwrite");
@@ -82,44 +102,57 @@ async function upsert<TSlug extends CatalogueSlug>(
   // (it is not, here).
   const publishedBase = { ...base, _status: "published" as const };
 
-  let id: string;
+  let written: Record<string, unknown>;
   if (existing) {
-    // `payload.update`'s data type is `DeepPartial<MarkOptional<DataFromCollectionSlug<TSlug>, ...>>`
-    // built through a nested generic composition that TypeScript cannot prove assignable for an
-    // abstract `TSlug` even though it holds for every concrete slug (verified: the identical
-    // assignment typechecks with a literal collection slug, only the generic-through-generic
-    // case fails) — see https://github.com/microsoft/TypeScript/issues/13995-style limitation.
-    // `payload.create` right below has no such issue and typechecks `publishedBase` against the
-    // real collection shape with no cast, which is what actually catches a mapper/collection
-    // mismatch; this cast only works around the `update` composition, not a real mismatch.
-    const doc = await payload.update({
+    // `payload.update`'s data type is `DeepPartial<MarkOptional<DataFromCollectionSlug<TSlug>, ...>>`,
+    // composed through nested generics. TypeScript cannot prove that composition assignable while
+    // `TSlug` is still abstract, even though it holds for every concrete slug — the identical
+    // assignment typechecks once the collection slug is a literal, and only the
+    // generic-through-generic case fails. `payload.create` right below has no such issue and
+    // typechecks `publishedBase` against the real collection shape with no cast, which is what
+    // actually catches a mapper/collection mismatch; this cast only works around the `update`
+    // composition, not a real mismatch.
+    written = (await payload.update({
       collection,
       id: existing,
       data: publishedBase as never,
       locale: "en",
       draft: false,
+      depth: 0,
       req,
-    });
-    id = doc.id as string;
+    })) as Record<string, unknown>;
     counts[collection].updated += 1;
   } else {
-    const doc = await payload.create({
+    written = (await payload.create({
       collection,
       data: publishedBase,
       locale: "en",
       draft: false,
+      depth: 0,
       req,
-    });
-    id = doc.id as string;
+    })) as Record<string, unknown>;
     counts[collection].created += 1;
     created[collection].add(legacyId);
   }
+  const id = written.id as string;
+
+  const carried = Object.fromEntries(
+    (CARRIED_TO_TRANSLATIONS[collection] ?? []).map((field) => [field, written[field]]),
+  );
 
   for (const locale of TRANSLATION_LOCALES) {
     const data = locales[locale];
     if (!data || Object.keys(data).length === 0) continue;
     // Same `update` generic-composition limitation as above.
-    await payload.update({ collection, id, data: data as never, locale, draft: false, req });
+    await payload.update({
+      collection,
+      id,
+      data: { ...carried, ...data } as never,
+      locale,
+      draft: false,
+      depth: 0,
+      req,
+    });
   }
 
   return id;
@@ -268,7 +301,9 @@ async function main() {
       console.log("\n  ✅ committed\n");
     }
   } finally {
-    await payload.destroy();
+    // Swallowed on purpose: a `destroy` rejection thrown from `finally` would replace the
+    // original error and lose the mapper's row-naming diagnostic.
+    await payload.destroy().catch((e) => console.error("  destroy failed:", e));
   }
 }
 

--- a/client/scripts/seed-catalogue.ts
+++ b/client/scripts/seed-catalogue.ts
@@ -7,6 +7,7 @@ import {
 
 import config from "@payload-config";
 
+import { buildTranslationData } from "@/cms/seed/carry-translations";
 import { describeAppliedFixes } from "@/cms/seed/fixes";
 import { mapDefaultVisualization } from "@/cms/seed/map-default-visualization";
 import { mapIndicatorBase, mapIndicatorLocale } from "@/cms/seed/map-indicator";
@@ -37,6 +38,14 @@ type CatalogueSlug = "topics" | "subtopics" | "indicators";
  * returned them, ids included. That is what the admin UI itself does when a locale tab is
  * saved, and it seeds the untranslated labels with the English text that locale fallback was
  * already showing readers.
+ *
+ * ⚠ This is destructive under `--overwrite`. The carried block always holds the English
+ * labels, and nothing here can tell an editor's hand-typed Spanish label from one that was
+ * never translated — `mapIndicatorLocale` does not return `resource`, so there is no
+ * per-locale value to compare against. A `--overwrite` run against a catalogue whose
+ * `popupTemplate.fieldInfos[].label` or `legend.items[].label` have been translated in the
+ * admin UI will silently reset every one of them to English. Read the note on `overwrite`
+ * below before reaching for that flag on a live catalogue.
  */
 const CARRIED_TO_TRANSLATIONS: Partial<Record<CatalogueSlug, readonly string[]>> = {
   indicators: ["resource"],
@@ -44,6 +53,19 @@ const CARRIED_TO_TRANSLATIONS: Partial<Record<CatalogueSlug, readonly string[]>>
 
 const args = new Set(process.argv.slice(2));
 const dryRun = args.has("--dry-run");
+
+/**
+ * ⚠ `--overwrite` rewrites existing rows from the source JSON instead of skipping them, and it
+ * loses editor work in the admin UI. The clearest case is the localized block labels described
+ * on `CARRIED_TO_TRANSLATIONS` above: every translated `popupTemplate.fieldInfos[].label` and
+ * `legend.items[].label` is reset to its English source text, with no warning and no way to
+ * tell which ones had been translated. Anything else an editor changed on a seeded field goes
+ * the same way, since the source row is written verbatim.
+ *
+ * It is safe on a catalogue nobody has edited — a re-import, or fixing a bad seed. Treat it as
+ * unsafe on a live one. As of this writing it has never been run against a real database, only
+ * typechecked.
+ */
 const overwrite = args.has("--overwrite");
 
 /** Documents this run created, per collection — pass 4 only backfills these. */
@@ -135,10 +157,7 @@ async function upsert<TSlug extends CatalogueSlug>(
     created[collection].add(legacyId);
   }
   const id = written.id as string;
-
-  const carried = Object.fromEntries(
-    (CARRIED_TO_TRANSLATIONS[collection] ?? []).map((field) => [field, written[field]]),
-  );
+  const carryFields = CARRIED_TO_TRANSLATIONS[collection] ?? [];
 
   for (const locale of TRANSLATION_LOCALES) {
     const data = locales[locale];
@@ -147,7 +166,7 @@ async function upsert<TSlug extends CatalogueSlug>(
     await payload.update({
       collection,
       id,
-      data: { ...carried, ...data } as never,
+      data: buildTranslationData(written, carryFields, data) as never,
       locale,
       draft: false,
       depth: 0,

--- a/client/scripts/seed-catalogue.ts
+++ b/client/scripts/seed-catalogue.ts
@@ -1,3 +1,38 @@
+/**
+ * Writes `client/datum/{topics,subtopics,indicators}.json` into the topics/subtopics/indicators
+ * CMS collections as published, multi-locale documents. This is the write path — see
+ * `scripts/verify-catalogue.ts` for the read-only audit that should follow every run.
+ *
+ * ⚠ Always invoke this through `pnpm seed:catalogue`, never `payload run
+ * scripts/seed-catalogue.ts` directly.
+ *
+ * `client/package.json`'s `seed:catalogue` script is `payload run scripts/seed-catalogue.ts --`.
+ * That trailing `--` is not decorative — it is the entire reason flags below reach this file at
+ * all. `payload run` parses its own CLI invocation with `minimist` and then rebuilds
+ * `process.argv` from `minimist`'s *positional* arguments (`args._`) only, dropping everything
+ * `minimist` consumed as a named option. Without the `--`, minimist parses a flag like
+ * `--dry-run` as `{ 'dry-run': true }` — a named option, not a positional — so it never appears
+ * in `args._` and is silently discarded before this script's own `process.argv` is rebuilt.
+ * Concretely:
+ *
+ *   payload run scripts/seed-catalogue.ts --dry-run     — `--dry-run` is dropped; this runs
+ *                                                          as a REAL, COMMITTED write
+ *   payload run scripts/seed-catalogue.ts -- --dry-run  — `--dry-run` survives as a literal
+ *                                                          positional and reaches this file
+ *
+ * The obvious moves that skip the `--` — running `payload run scripts/seed-catalogue.ts
+ * --dry-run` directly while debugging, or invoking it in a container without the pnpm scripts —
+ * both silently commit. Always go through `pnpm seed:catalogue -- <flags>`.
+ *
+ *   pnpm seed:catalogue -- --dry-run                — rehearse: build everything, roll back
+ *   pnpm seed:catalogue -- --overwrite --yes         — also rewrite existing rows (destructive
+ *                                                       to translated labels — see the
+ *                                                       CARRIED_TO_TRANSLATIONS comment below)
+ *
+ * As a second line of defence, unknown flags (`--dryrun`, `--dry_run`, `-n`, `--overwite`, …)
+ * are rejected before any database connection opens rather than silently ignored — see
+ * KNOWN_FLAGS below.
+ */
 import {
   getPayload,
   type Payload,
@@ -6,6 +41,8 @@ import {
 } from "payload";
 
 import config from "@payload-config";
+
+import { env } from "@/env.mjs";
 
 import { buildTranslationData } from "@/cms/seed/carry-translations";
 import { describeAppliedFixes } from "@/cms/seed/fixes";
@@ -20,6 +57,7 @@ import {
   TRANSLATION_LOCALES,
   type Locale,
 } from "@/cms/seed/source";
+import { getDatabaseUrlFromUrlAndPassword } from "@/utils/database-url";
 
 type CatalogueSlug = "topics" | "subtopics" | "indicators";
 
@@ -51,8 +89,57 @@ const CARRIED_TO_TRANSLATIONS: Partial<Record<CatalogueSlug, readonly string[]>>
   indicators: ["resource"],
 };
 
-const args = new Set(process.argv.slice(2));
-const dryRun = args.has("--dry-run");
+/**
+ * Every flag this script understands. Anything else on the command line — a typo like
+ * `--dryrun`/`--dry_run`/`-n`/`--overwite`, or a flag from a different script entirely — throws
+ * immediately rather than being silently ignored. This is the same failure class as the
+ * `payload run` argv-drop problem documented in the file header, closed at this script's own
+ * argument-parsing layer instead of relying on every flag name being guessed correctly by
+ * whoever is invoking it.
+ *
+ * A bare `--` is allowed through unexamined: `pnpm seed:catalogue -- --dry-run` legitimately
+ * puts a literal `--` in `process.argv` here. `payload run` rebuilds `process.argv` from
+ * minimist's positional arguments only (see the file header); minimist treats the *first* `--`
+ * in its input as "stop parsing flags", consuming it, but a *second* `--` — the one contributed
+ * by `pnpm run seed:catalogue -- --dry-run` on top of the `--` already baked into the
+ * `seed:catalogue` package script — is just another positional string and survives verbatim
+ * into this script's argv alongside the real flags.
+ */
+const KNOWN_FLAGS = new Set(["--dry-run", "--overwrite", "--yes"]);
+
+function parseArgs(argv: readonly string[]): { dryRun: boolean; overwrite: boolean; yes: boolean } {
+  for (const arg of argv) {
+    if (arg === "--") continue;
+    if (!KNOWN_FLAGS.has(arg)) {
+      throw new Error(
+        `unknown flag ${arg} (known flags: ${[...KNOWN_FLAGS].join(", ")}) — invoke this ` +
+          `script via "pnpm seed:catalogue -- <flags>"; see the file header for why the "--" ` +
+          `matters`,
+      );
+    }
+  }
+  const flags = new Set(argv);
+  return {
+    dryRun: flags.has("--dry-run"),
+    overwrite: flags.has("--overwrite"),
+    yes: flags.has("--yes"),
+  };
+}
+
+const { dryRun, overwrite, yes } = parseArgs(process.argv.slice(2));
+
+/**
+ * Prints the database this run is about to write to — host and database name only, never the
+ * password or the full connection string — before any write happens, on every run (not just
+ * `--overwrite`). Reuses `getDatabaseUrlFromUrlAndPassword` (see `src/utils/database-url.ts`)
+ * to resolve the same env vars `payload.config.ts` does, rather than re-parsing `DATABASE_URL`
+ * by hand.
+ */
+function printDatabaseTarget(): void {
+  const resolvedUrl = getDatabaseUrlFromUrlAndPassword(env.DATABASE_URL, env.DATABASE_PASSWORD);
+  const { host, pathname } = new URL(resolvedUrl);
+  console.log(`\n  target      ${host}${pathname}`);
+}
 
 /**
  * ⚠ `--overwrite` rewrites existing rows from the source JSON instead of skipping them, and it
@@ -63,10 +150,38 @@ const dryRun = args.has("--dry-run");
  * the same way, since the source row is written verbatim.
  *
  * It is safe on a catalogue nobody has edited — a re-import, or fixing a bad seed. Treat it as
- * unsafe on a live one. As of this writing it has never been run against a real database, only
- * typechecked.
+ * unsafe on a live one.
+ *
+ * `--overwrite` alone therefore refuses to run: it requires an explicit `--yes` alongside it,
+ * checked here before any database connection opens (no interactive prompt — this has to stay
+ * non-interactive for CI and scripted use). `--yes` is required even under `--dry-run`: a dry
+ * run's transaction is rolled back, so nothing is actually destroyed, but the flag's meaning
+ * ("I intend the destructive rewrite") should not change depending on `--dry-run`, and an
+ * operator rehearsing a run should confirm the same thing they will need to confirm for real.
  */
-const overwrite = args.has("--overwrite");
+function assertOverwriteConfirmed(): void {
+  if (!overwrite || yes) return;
+
+  console.error(`
+  ❌ --overwrite refused: --yes is required.
+
+  --overwrite rewrites every existing topic, subtopic and indicator row from the source JSON.
+  In particular, it resets any editor-translated label back to its English source text on:
+
+    - resource[].popupTemplate.fieldInfos[].label
+    - resource[].legend.items[].label
+
+  Any other field an editor changed on a seeded row is overwritten the same way, since the
+  source row is written back verbatim. This applies even under --dry-run, whose transaction is
+  rolled back but whose intent should still be confirmed explicitly.
+
+  Re-run with "--overwrite --yes" once you have confirmed this is what you want.
+`);
+  process.exit(1);
+}
+
+printDatabaseTarget();
+assertOverwriteConfirmed();
 
 /** Documents this run created, per collection — pass 4 only backfills these. */
 const created = {

--- a/client/scripts/verify-catalogue.ts
+++ b/client/scripts/verify-catalogue.ts
@@ -11,14 +11,35 @@ import { getPayload, type Payload } from "payload";
 
 import config from "@payload-config";
 
-import { LOCALES, type Locale } from "@/cms/seed/source";
+import { LOCALES, rawIndicators, rawSubtopics, rawTopics, type Locale } from "@/cms/seed/source";
 
 type CatalogueSlug = "topics" | "subtopics" | "indicators";
 
 const SLUGS = ["topics", "subtopics", "indicators"] as const satisfies readonly CatalogueSlug[];
 
-const EXPECTED_ROWS: Record<CatalogueSlug, number> = { topics: 9, subtopics: 28, indicators: 164 };
-const EXPECTED_DEFAULT_VIS = { topics: 8, subtopics: 28 } as const;
+/**
+ * Both derived from the source JSON rather than hand-typed, so the audit tracks the source
+ * instead of rotting against it: add an indicator to `datum/indicators.json` and this stays
+ * correct instead of FAILing for the wrong reason (a stale expected count), and removing one
+ * no longer risks a PASS while an orphaned published document lingers — see the legacy_id
+ * set-equality check below, which is what actually catches that second case.
+ */
+const EXPECTED_ROWS: Record<CatalogueSlug, number> = {
+  topics: rawTopics.length,
+  subtopics: rawSubtopics.length,
+  indicators: rawIndicators.length,
+};
+const EXPECTED_DEFAULT_VIS = {
+  topics: rawTopics.filter((r) => r.default_visualization?.length).length,
+  subtopics: rawSubtopics.filter((r) => r.default_visualization?.length).length,
+} as const;
+
+/** The `raw*` source arrays, keyed the same way as `EXPECTED_ROWS`/`SLUGS`. */
+const RAW_SOURCE: Record<CatalogueSlug, readonly { id: number }[]> = {
+  topics: rawTopics,
+  subtopics: rawSubtopics,
+  indicators: rawIndicators,
+};
 
 const expectEmpty = process.argv.slice(2).includes("--expect-empty");
 
@@ -163,6 +184,40 @@ function auditDefaultVisualization(views: Views) {
   }
 }
 
+/**
+ * Set-equality between the `legacy_id`s live in the database and the ids in the source JSON.
+ *
+ * Every other check in this file assumes the two are in sync; nothing before this one would
+ * catch a source deletion (a row removed from `datum/*.json` but never removed from the
+ * database — the row would keep passing `auditStatus`/`auditLocales` forever) or an orphaned
+ * database row (present here for some other reason, no matching source id). This is the one
+ * drift direction the rest of the audit is blind to.
+ */
+function auditLegacyIdCoverage(views: Views) {
+  console.log("\nSource drift — legacy_id set equality against datum/*.json\n");
+
+  for (const slug of SLUGS) {
+    const dbIds = new Set(
+      views[slug].live.map((r) => r.legacy_id).filter((id): id is number => typeof id === "number"),
+    );
+    const sourceIds = new Set(RAW_SOURCE[slug].map((r) => r.id));
+
+    const missingFromDb = [...sourceIds].filter((id) => !dbIds.has(id)).sort((a, b) => a - b);
+    const orphanedInDb = [...dbIds].filter((id) => !sourceIds.has(id)).sort((a, b) => a - b);
+
+    check(
+      missingFromDb.length === 0,
+      `${slug.padEnd(10)} ${missingFromDb.length} source id(s) missing from the database`,
+      missingFromDb.length ? `legacy_id: ${missingFromDb.slice(0, 20).join(", ")}` : undefined,
+    );
+    check(
+      orphanedInDb.length === 0,
+      `${slug.padEnd(10)} ${orphanedInDb.length} database row(s) with no matching source id`,
+      orphanedInDb.length ? `legacy_id: ${orphanedInDb.slice(0, 20).join(", ")}` : undefined,
+    );
+  }
+}
+
 async function auditFixes(payload: Payload) {
   console.log("\nTargeted spot checks\n");
 
@@ -257,6 +312,7 @@ async function main() {
     auditStatus(views);
     await auditLocales(payload);
     auditDefaultVisualization(views);
+    auditLegacyIdCoverage(views);
     await auditFixes(payload);
     console.log("");
   } finally {

--- a/client/scripts/verify-catalogue.ts
+++ b/client/scripts/verify-catalogue.ts
@@ -1,0 +1,276 @@
+/**
+ * Read-only audit of the seeded catalogue. Never writes: no create, no update, no delete,
+ * no transaction. Run it after `pnpm seed:catalogue` to prove the catalogue is complete,
+ * published and translated, and re-run it after future migrations.
+ *
+ * `pnpm verify:catalogue`                — full audit, expects a seeded catalogue
+ * `pnpm verify:catalogue -- --expect-empty` — asserts the three tables are empty instead,
+ *                                            which is how the dry run's rollback is proved
+ */
+import { getPayload, type Payload } from "payload";
+
+import config from "@payload-config";
+
+import { LOCALES, type Locale } from "@/cms/seed/source";
+
+type CatalogueSlug = "topics" | "subtopics" | "indicators";
+
+const SLUGS = ["topics", "subtopics", "indicators"] as const satisfies readonly CatalogueSlug[];
+
+const EXPECTED_ROWS: Record<CatalogueSlug, number> = { topics: 9, subtopics: 28, indicators: 164 };
+const EXPECTED_DEFAULT_VIS = { topics: 8, subtopics: 28 } as const;
+
+const expectEmpty = process.argv.slice(2).includes("--expect-empty");
+
+/** A catalogue document, read loosely — the audit only touches fields all three share. */
+type Row = {
+  id: string;
+  legacy_id?: number | null;
+  name?: string | null;
+  _status?: string | null;
+  default_visualization?: unknown[] | null;
+  visualization_types?: unknown;
+  resource?: unknown;
+};
+
+let failures = 0;
+
+function check(ok: boolean, label: string, detail?: string) {
+  if (!ok) failures += 1;
+  console.log(`  ${ok ? "PASS" : "FAIL"}  ${label}${detail ? `  — ${detail}` : ""}`);
+}
+
+/**
+ * Every row of a collection in one locale, relationships unresolved.
+ *
+ * `draft: true` reads the versions table and returns each document's newest version;
+ * `draft: false` reads the live collection table, which is what the app itself sees. Both
+ * are audited, because a row can only be trusted when it is published in both views.
+ */
+async function readAll(
+  payload: Payload,
+  collection: CatalogueSlug,
+  locale: Locale,
+  draft = true,
+): Promise<Row[]> {
+  const { docs } = await payload.find({
+    collection,
+    locale,
+    // Without this, a missing es/pt name silently falls back to en and the locale audit
+    // below would pass on every row regardless of whether translations were written.
+    fallbackLocale: false,
+    draft,
+    depth: 0,
+    limit: 0,
+    pagination: false,
+    overrideAccess: true,
+  });
+  return docs as unknown as Row[];
+}
+
+async function one(
+  payload: Payload,
+  collection: CatalogueSlug,
+  legacyId: number,
+  { locale = "en", depth = 0 }: { locale?: Locale; depth?: number } = {},
+): Promise<Row | undefined> {
+  const { docs } = await payload.find({
+    collection,
+    where: { legacy_id: { equals: legacyId } },
+    locale,
+    fallbackLocale: false,
+    draft: true,
+    depth,
+    limit: 1,
+    pagination: false,
+    overrideAccess: true,
+  });
+  return docs[0] as unknown as Row | undefined;
+}
+
+function legacyIds(rows: Row[]): string {
+  return rows
+    .map((r) => r.legacy_id ?? "?")
+    .slice(0, 20)
+    .join(", ");
+}
+
+type Views = Record<CatalogueSlug, { versions: Row[]; live: Row[] }>;
+
+async function auditCounts(payload: Payload): Promise<Views> {
+  console.log("\nRow counts\n");
+  const views = {} as Views;
+
+  for (const slug of SLUGS) {
+    const versions = await readAll(payload, slug, "en", true);
+    const live = await readAll(payload, slug, "en", false);
+    views[slug] = { versions, live };
+
+    const expected = expectEmpty ? 0 : EXPECTED_ROWS[slug];
+    check(
+      versions.length === expected && live.length === expected,
+      `${slug.padEnd(10)} ${versions.length} rows (expected ${expected})`,
+      `${live.length} in the live collection table`,
+    );
+  }
+
+  return views;
+}
+
+function auditStatus(views: Views) {
+  console.log("\nPublish status — the assertion that matters most\n");
+
+  for (const slug of SLUGS) {
+    for (const [view, rows] of [
+      ["newest version", views[slug].versions],
+      ["live table   ", views[slug].live],
+    ] as const) {
+      const unpublished = rows.filter((r) => r._status !== "published");
+      check(
+        unpublished.length === 0,
+        `${slug.padEnd(10)} ${view}  ${unpublished.length} of ${rows.length} rows not published`,
+        unpublished.length ? `legacy_id: ${legacyIds(unpublished)}` : undefined,
+      );
+    }
+  }
+}
+
+async function auditLocales(payload: Payload) {
+  console.log("\nLocale coverage — blank `name` per locale, no en fallback\n");
+
+  for (const slug of SLUGS) {
+    for (const locale of LOCALES) {
+      const rows = await readAll(payload, slug, locale);
+      const blank = rows.filter((r) => !r.name || String(r.name).trim() === "");
+      check(
+        blank.length === 0,
+        `${slug.padEnd(10)} ${locale}  ${blank.length} blank names of ${rows.length}`,
+        blank.length ? `legacy_id: ${legacyIds(blank)}` : undefined,
+      );
+    }
+  }
+}
+
+function auditDefaultVisualization(views: Views) {
+  console.log("\ndefault_visualization backfill\n");
+
+  for (const slug of ["topics", "subtopics"] as const) {
+    const withEntries = views[slug].live.filter((r) => (r.default_visualization?.length ?? 0) > 0);
+    check(
+      withEntries.length === EXPECTED_DEFAULT_VIS[slug],
+      `${slug.padEnd(10)} ${withEntries.length} rows with entries (expected ${EXPECTED_DEFAULT_VIS[slug]})`,
+    );
+  }
+}
+
+async function auditFixes(payload: Payload) {
+  console.log("\nTargeted spot checks\n");
+
+  // Fix 1 — subtopic 26's only default_visualization entry was repointed from the deleted
+  // indicator 55 to indicator 146. depth: 1 so the relationship resolves to its legacy_id.
+  const subtopic26 = await one(payload, "subtopics", 26, { depth: 1 });
+  const entries = (subtopic26?.default_visualization ?? []) as {
+    indicator?: { legacy_id?: number };
+  }[];
+  check(
+    entries.length === 1 && entries[0]?.indicator?.legacy_id === 146,
+    "fix 1  subtopics 26 default_visualization -> indicator legacy_id 146",
+    `${entries.length} entries, resolved legacy_id ${entries[0]?.indicator?.legacy_id ?? "none"}`,
+  );
+
+  // Fix 2 — indicator 5 gained the chart widget.
+  const indicator5 = await one(payload, "indicators", 5);
+  const types = (indicator5?.visualization_types ?? []) as string[];
+  check(
+    types.includes("chart"),
+    "fix 2  indicators 5 visualization_types includes chart",
+    `[${types.join(", ")}]`,
+  );
+
+  // Fix 3 — indicator 12 is a feature block, so its bogus rasterFunction was dropped.
+  const indicator12 = await one(payload, "indicators", 12);
+  const block12 = ((indicator12?.resource ?? []) as Record<string, unknown>[])[0] ?? {};
+  check(
+    block12.blockType === "feature" && !("rasterFunction" in block12),
+    "fix 3  indicators 12 resource[0] is feature with no rasterFunction",
+    `blockType ${String(block12.blockType)}, rasterFunction ${"rasterFunction" in block12 ? "present" : "absent"}`,
+  );
+
+  // Fix 4 + translations — trimmed en name, and a real es translation.
+  const subtopic3En = await one(payload, "subtopics", 3, { locale: "en" });
+  const subtopic3Es = await one(payload, "subtopics", 3, { locale: "es" });
+  check(
+    subtopic3En?.name === "Land Cover",
+    "fix 4  subtopics 3 en name is exactly 'Land Cover'",
+    JSON.stringify(subtopic3En?.name),
+  );
+  check(
+    subtopic3Es?.name === "Cobertura del Suelo",
+    "        subtopics 3 es name is 'Cobertura del Suelo'",
+    JSON.stringify(subtopic3Es?.name),
+  );
+
+  // Nested trim — the trim reaches inside block subfields, not just top-level text.
+  const indicator140 = await one(payload, "indicators", 140);
+  const block140 = ((indicator140?.resource ?? []) as Record<string, unknown>[])[0] ?? {};
+  const fieldName = ((
+    block140.popupTemplate as { fieldInfos?: { fieldName?: string }[] } | undefined
+  )?.fieldInfos ?? [])[0]?.fieldName;
+  check(
+    fieldName === "LENGTHm",
+    "trim   indicators 140 resource[0].popupTemplate.fieldInfos[0].fieldName is 'LENGTHm'",
+    JSON.stringify(fieldName),
+  );
+
+  // `popupTemplate.fieldInfos[].label` is localized and required, so the seed carries the
+  // block array into the es/pt writes. Assert the outcome directly: the labels are present in
+  // every locale, and carrying the blocks three times did not duplicate the block rows.
+  for (const locale of LOCALES) {
+    const doc = await one(payload, "indicators", 5, { locale });
+    const blocks = (doc?.resource ?? []) as {
+      popupTemplate?: { fieldInfos?: { label?: string }[] };
+    }[];
+    const labels = (blocks[0]?.popupTemplate?.fieldInfos ?? []).map((f) => f.label);
+    check(
+      blocks.length === 1 && labels.length === 2 && labels.every((l) => !!l && l.trim() !== ""),
+      `blocks indicators 5 ${locale}  1 resource block, 2 non-blank popup labels`,
+      `${blocks.length} blocks, labels ${JSON.stringify(labels)}`,
+    );
+  }
+}
+
+async function main() {
+  const payload = await getPayload({ config });
+
+  try {
+    console.log(
+      `\nVerifying catalogue (${expectEmpty ? "expecting empty tables" : "expecting a full seed"})`,
+    );
+
+    const views = await auditCounts(payload);
+
+    if (expectEmpty) {
+      console.log("\n  content assertions skipped in --expect-empty mode\n");
+      return;
+    }
+
+    auditStatus(views);
+    await auditLocales(payload);
+    auditDefaultVisualization(views);
+    await auditFixes(payload);
+    console.log("");
+  } finally {
+    await payload.destroy().catch((e) => console.error("  destroy failed:", e));
+  }
+}
+
+await main().catch((error) => {
+  console.error("\n  ❌ verification failed to run:", error);
+  process.exit(1);
+});
+
+if (failures > 0) {
+  console.error(`  ❌ ${failures} assertion(s) failed\n`);
+  process.exit(1);
+}
+console.log("  ✅ all assertions passed\n");

--- a/client/src/cms/seed/carry-translations.test.ts
+++ b/client/src/cms/seed/carry-translations.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { buildTranslationData } from "./carry-translations";
+
+/** Shaped like the document `payload.create` returns for an indicator, at depth 0. */
+const writtenIndicator = () => ({
+  id: "doc-1",
+  legacy_id: 5,
+  name: "Administrative Capitals",
+  resource: [
+    {
+      id: "block-1",
+      blockType: "feature",
+      url: "https://example.com/FeatureServer/0",
+      layer_id: "0",
+      popupTemplate: {
+        title: "{NOMBCAP}",
+        fieldInfos: [
+          { id: "info-1", fieldName: "NAME_1", label: "State" },
+          { id: "info-2", fieldName: "NAME_0", label: "Country" },
+        ],
+      },
+    },
+  ],
+});
+
+const localeText = { name: "Capitales Administrativas", description_short: "…" };
+
+describe("buildTranslationData", () => {
+  it("carries the block array over with the ids payload assigned", () => {
+    const data = buildTranslationData(writtenIndicator(), ["resource"], localeText);
+    const resource = data.resource as { id: string; popupTemplate: { fieldInfos: unknown[] } }[];
+
+    // The regression this guards: lose the ids and Payload deletes and recreates the block
+    // rows on every locale write instead of reusing them.
+    expect(resource[0].id).toBe("block-1");
+    expect(resource[0].popupTemplate.fieldInfos).toEqual([
+      { id: "info-1", fieldName: "NAME_1", label: "State" },
+      { id: "info-2", fieldName: "NAME_0", label: "Country" },
+    ]);
+  });
+
+  it("keeps the locale's own fields alongside the carried ones", () => {
+    const data = buildTranslationData(writtenIndicator(), ["resource"], localeText);
+
+    expect(data.name).toBe("Capitales Administrativas");
+    expect(data.description_short).toBe("…");
+    expect(data).toHaveProperty("resource");
+  });
+
+  it("does not let the locale payload override a carried field", () => {
+    const data = buildTranslationData(writtenIndicator(), ["resource"], {
+      ...localeText,
+      // A locale mapper emitting `resource` — partial, id-less, and missing the required
+      // localized labels — must not win, or the validation failure comes straight back.
+      resource: [{ blockType: "feature", url: "https://example.com/other" }],
+    });
+    const resource = data.resource as { id: string }[];
+
+    expect(resource).toHaveLength(1);
+    expect(resource[0].id).toBe("block-1");
+  });
+
+  it("returns only the locale payload when nothing is carried", () => {
+    // The topics and subtopics path: neither collection carries any field.
+    expect(buildTranslationData(writtenIndicator(), [], localeText)).toEqual(localeText);
+  });
+
+  it("omits a carried field that the written document does not have", () => {
+    const data = buildTranslationData({ id: "doc-1" }, ["resource"], localeText);
+
+    expect(data).not.toHaveProperty("resource");
+    expect(data).toEqual(localeText);
+  });
+
+  it("does not mutate the written document or the locale payload", () => {
+    const written = writtenIndicator();
+    const locale = { ...localeText };
+    buildTranslationData(written, ["resource"], locale);
+
+    expect(written).toEqual(writtenIndicator());
+    expect(locale).toEqual(localeText);
+  });
+});

--- a/client/src/cms/seed/carry-translations.test.ts
+++ b/client/src/cms/seed/carry-translations.test.ts
@@ -48,17 +48,23 @@ describe("buildTranslationData", () => {
     expect(data).toHaveProperty("resource");
   });
 
-  it("does not let the locale payload override a carried field", () => {
-    const data = buildTranslationData(writtenIndicator(), ["resource"], {
-      ...localeText,
-      // A locale mapper emitting `resource` — partial, id-less, and missing the required
-      // localized labels — must not win, or the validation failure comes straight back.
-      resource: [{ blockType: "feature", url: "https://example.com/other" }],
-    });
-    const resource = data.resource as { id: string }[];
-
-    expect(resource).toHaveLength(1);
-    expect(resource[0].id).toBe("block-1");
+  it("throws when a locale mapper starts emitting a field that is also carried", () => {
+    // A locale mapper emitting `resource` — partial, id-less, and missing the required
+    // localized labels — must not be silently discarded or silently allowed to win; either
+    // one would hide a real collision. See CARRIED_TO_TRANSLATIONS in
+    // scripts/seed-catalogue.ts for where to resolve it.
+    expect(() =>
+      buildTranslationData(writtenIndicator(), ["resource"], {
+        ...localeText,
+        resource: [{ blockType: "feature", url: "https://example.com/other" }],
+      }),
+    ).toThrow(/resource/);
+    expect(() =>
+      buildTranslationData(writtenIndicator(), ["resource"], {
+        ...localeText,
+        resource: [{ blockType: "feature", url: "https://example.com/other" }],
+      }),
+    ).toThrow(/CARRIED_TO_TRANSLATIONS/);
   });
 
   it("returns only the locale payload when nothing is carried", () => {

--- a/client/src/cms/seed/carry-translations.ts
+++ b/client/src/cms/seed/carry-translations.ts
@@ -1,0 +1,35 @@
+/**
+ * Builds the `data` for a translation write: the locale's own text fields, plus the structural
+ * fields carried over from the `en` write.
+ *
+ * Extracted from the seed shell purely so it can be tested. `scripts/seed-catalogue.ts` runs
+ * `main()` at module scope, so importing `upsert` from a test would open a database connection
+ * and run the whole seed; this function is the part of that write path with real logic in it.
+ *
+ * Two behaviours the seed depends on:
+ *
+ * 1. **Ids survive.** Values are taken from the document the `en` write returned, so Payload
+ *    block and array rows keep the ids it assigned and are matched and reused on the next
+ *    write instead of being deleted and recreated.
+ * 2. **Carried fields win over the locale payload.** Their job is to guarantee that required
+ *    localized subfields exist in every locale (see `CARRIED_TO_TRANSLATIONS` in
+ *    `scripts/seed-catalogue.ts` for why). A locale mapper that started emitting one of these
+ *    fields — with a partial value, or none at all — would silently reintroduce the validation
+ *    failure the carry exists to prevent, so the carried value takes precedence. Emitting a
+ *    field per locale on purpose means dropping it from the carry list.
+ *
+ * A carried field that is absent from the written document is omitted rather than sent as
+ * `undefined`.
+ */
+export function buildTranslationData(
+  written: Record<string, unknown>,
+  carryFields: readonly string[],
+  localeData: Record<string, unknown>,
+): Record<string, unknown> {
+  const carried = Object.fromEntries(
+    carryFields
+      .filter((field) => written[field] !== undefined)
+      .map((field) => [field, written[field]]),
+  );
+  return { ...localeData, ...carried };
+}

--- a/client/src/cms/seed/carry-translations.ts
+++ b/client/src/cms/seed/carry-translations.ts
@@ -11,12 +11,16 @@
  * 1. **Ids survive.** Values are taken from the document the `en` write returned, so Payload
  *    block and array rows keep the ids it assigned and are matched and reused on the next
  *    write instead of being deleted and recreated.
- * 2. **Carried fields win over the locale payload.** Their job is to guarantee that required
- *    localized subfields exist in every locale (see `CARRIED_TO_TRANSLATIONS` in
- *    `scripts/seed-catalogue.ts` for why). A locale mapper that started emitting one of these
- *    fields — with a partial value, or none at all — would silently reintroduce the validation
- *    failure the carry exists to prevent, so the carried value takes precedence. Emitting a
- *    field per locale on purpose means dropping it from the carry list.
+ * 2. **Carried fields never silently lose to — or silently win over — the locale payload.**
+ *    Their job is to guarantee that required localized subfields exist in every locale (see
+ *    `CARRIED_TO_TRANSLATIONS` in `scripts/seed-catalogue.ts` for why). Today no locale mapper
+ *    emits a field that is also carried, so there is nothing to prefer one way or the other —
+ *    a collision means a locale mapper started emitting a real per-locale value for a field
+ *    that `CARRIED_TO_TRANSLATIONS` still carries wholesale from the `en` write, and either
+ *    resolution (silently keep the carried value, or silently let the locale value through)
+ *    would hide that. This throws instead: fix it by removing the field from
+ *    `CARRIED_TO_TRANSLATIONS` in `scripts/seed-catalogue.ts` once the locale mapper covers it
+ *    for real.
  *
  * A carried field that is absent from the written document is omitted rather than sent as
  * `undefined`.
@@ -31,5 +35,17 @@ export function buildTranslationData(
       .filter((field) => written[field] !== undefined)
       .map((field) => [field, written[field]]),
   );
+
+  for (const key of Object.keys(carried)) {
+    if (key in localeData) {
+      throw new Error(
+        `buildTranslationData: "${key}" is present in both the locale payload and ` +
+          `CARRIED_TO_TRANSLATIONS. A locale mapper is now emitting a real value for a field ` +
+          `that scripts/seed-catalogue.ts's CARRIED_TO_TRANSLATIONS still carries wholesale ` +
+          `from the "en" write — remove "${key}" from CARRIED_TO_TRANSLATIONS there.`,
+      );
+    }
+  }
+
   return { ...localeData, ...carried };
 }

--- a/client/src/cms/seed/fixes.test.ts
+++ b/client/src/cms/seed/fixes.test.ts
@@ -39,10 +39,7 @@ describe("fix 2: indicator 5 gains chart", () => {
       "numeric",
       "chart",
     ]);
-    expect(fixVisualizationTypes(INDICATOR_ADDS_CHART, ["map", "chart"])).toEqual([
-      "map",
-      "chart",
-    ]);
+    expect(fixVisualizationTypes(INDICATOR_ADDS_CHART, ["map", "chart"])).toEqual(["map", "chart"]);
   });
 
   it("changes no other indicator", () => {
@@ -75,7 +72,11 @@ describe("fix 3: indicator 12 drops rasterFunction", () => {
 describe("describeAppliedFixes", () => {
   it("reports exactly the three named fixes against the real source", () => {
     expect(describeAppliedFixes()).toEqual([
-      { collection: "subtopics", legacy_id: 26, change: "default_visualization indicator 55 -> 146" },
+      {
+        collection: "subtopics",
+        legacy_id: 26,
+        change: "default_visualization indicator 55 -> 146",
+      },
       { collection: "indicators", legacy_id: 5, change: "visualization_types += chart" },
       { collection: "indicators", legacy_id: 12, change: "dropped resource.rasterFunction" },
     ]);

--- a/client/src/cms/seed/fixes.test.ts
+++ b/client/src/cms/seed/fixes.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  describeAppliedFixes,
+  fixVisualizationTypes,
+  INDICATOR_ADDS_CHART,
+  INDICATOR_DROPS_RASTER_FUNCTION,
+  resolveFixedIndicatorId,
+  SUBTOPIC_DEFAULT_VIS_FIX,
+} from "./fixes";
+import { rawIndicators, rawSubtopics } from "./source";
+
+describe("fix 1: subtopic 26 -> deleted indicator 55", () => {
+  it("repoints only subtopic 26's reference to 55", () => {
+    expect(resolveFixedIndicatorId(26, 55)).toBe(146);
+  });
+
+  it("leaves every other owner and indicator untouched", () => {
+    expect(resolveFixedIndicatorId(26, 146)).toBe(146);
+    expect(resolveFixedIndicatorId(27, 55)).toBe(55);
+    expect(resolveFixedIndicatorId(1, 3)).toBe(3);
+  });
+
+  it("targets a row that really is dangling, and a replacement that really exists", () => {
+    const ids = new Set(rawIndicators.map((i) => i.id));
+    expect(ids.has(SUBTOPIC_DEFAULT_VIS_FIX.from)).toBe(false);
+    expect(ids.has(SUBTOPIC_DEFAULT_VIS_FIX.to)).toBe(true);
+
+    const owner = rawSubtopics.find((s) => s.id === SUBTOPIC_DEFAULT_VIS_FIX.owner);
+    expect(owner?.default_visualization).toHaveLength(1);
+    expect(owner?.default_visualization?.[0].indicator_id).toBe(SUBTOPIC_DEFAULT_VIS_FIX.from);
+  });
+});
+
+describe("fix 2: indicator 5 gains chart", () => {
+  it("appends chart exactly once and preserves order", () => {
+    expect(fixVisualizationTypes(INDICATOR_ADDS_CHART, ["map", "numeric"])).toEqual([
+      "map",
+      "numeric",
+      "chart",
+    ]);
+    expect(fixVisualizationTypes(INDICATOR_ADDS_CHART, ["map", "chart"])).toEqual([
+      "map",
+      "chart",
+    ]);
+  });
+
+  it("changes no other indicator", () => {
+    expect(fixVisualizationTypes(6, ["map", "numeric"])).toEqual(["map", "numeric"]);
+    expect(fixVisualizationTypes(12, [])).toEqual([]);
+  });
+
+  it("targets a row that really has a query_chart it does not declare", () => {
+    const row = rawIndicators.find((i) => i.id === INDICATOR_ADDS_CHART);
+    expect(row?.resource.query_chart).toBeTruthy();
+    expect(row?.visualization_types).not.toContain("chart");
+  });
+});
+
+describe("fix 3: indicator 12 drops rasterFunction", () => {
+  it("targets a feature row that really carries a bare-string rasterFunction", () => {
+    const row = rawIndicators.find((i) => i.id === INDICATOR_DROPS_RASTER_FUNCTION);
+    expect(row?.resource.type).toBe("feature");
+    expect(row?.resource.rasterFunction).toBe("Forest_Cover_Change");
+  });
+
+  it("is the only feature row carrying one", () => {
+    const offenders = rawIndicators.filter(
+      (i) => i.resource.type === "feature" && Boolean(i.resource.rasterFunction),
+    );
+    expect(offenders.map((i) => i.id)).toEqual([INDICATOR_DROPS_RASTER_FUNCTION]);
+  });
+});
+
+describe("describeAppliedFixes", () => {
+  it("reports exactly the three named fixes against the real source", () => {
+    expect(describeAppliedFixes()).toEqual([
+      { collection: "subtopics", legacy_id: 26, change: "default_visualization indicator 55 -> 146" },
+      { collection: "indicators", legacy_id: 5, change: "visualization_types += chart" },
+      { collection: "indicators", legacy_id: 12, change: "dropped resource.rasterFunction" },
+    ]);
+  });
+});

--- a/client/src/cms/seed/fixes.ts
+++ b/client/src/cms/seed/fixes.ts
@@ -1,0 +1,74 @@
+import { rawIndicators, rawSubtopics } from "./source";
+
+/**
+ * Fix 1. Subtopic 26 "Security Infrastructure" has a single `default_visualization` entry
+ * pointing at indicator 55, which does not exist — the id sequence confirms deletion
+ * (50–54 and 56–60 are all present). Dropping the entry would leave the subtopic with no
+ * pre-configured widgets, so it is repointed at indicator 146 "Police Infrastructure
+ * Network": the first indicator by `order` in that subtopic, and it supports `map`.
+ * Geometry (`type: map, x0 y0 w2 h4`) is preserved by the caller.
+ */
+export const SUBTOPIC_DEFAULT_VIS_FIX = { owner: 26, from: 55, to: 146 } as const;
+
+/**
+ * Fix 2. Indicator 5 "Administrative Capitals" declares [map, numeric] but carries a
+ * `query_chart`. A deliberate product change: the chart widget becomes available.
+ */
+export const INDICATOR_ADDS_CHART = 5;
+
+/**
+ * Fix 3. Indicator 12 "Indigenous Territories" is `type: feature` but carries
+ * `rasterFunction: 'Forest_Cover_Change'` — a bare string where the shape is an object, on
+ * a layer type that cannot use raster functions. The `feature` block has no such field, so
+ * the value is dropped. Recorded so the drop is a decision, not an accident.
+ */
+export const INDICATOR_DROPS_RASTER_FUNCTION = 12;
+
+export function resolveFixedIndicatorId(ownerLegacyId: number, indicatorLegacyId: number): number {
+  const { owner, from, to } = SUBTOPIC_DEFAULT_VIS_FIX;
+  if (ownerLegacyId === owner && indicatorLegacyId === from) return to;
+  return indicatorLegacyId;
+}
+
+export function fixVisualizationTypes(legacyId: number, types: string[]): string[] {
+  if (legacyId !== INDICATOR_ADDS_CHART) return types;
+  if (types.includes("chart")) return types;
+  return [...types, "chart"];
+}
+
+export type FixReport = { collection: string; legacy_id: number; change: string };
+
+/** Inspects the real source so a logged fix is always one that actually applies. */
+export function describeAppliedFixes(): FixReport[] {
+  const reports: FixReport[] = [];
+
+  const { owner, from, to } = SUBTOPIC_DEFAULT_VIS_FIX;
+  const subtopic = rawSubtopics.find((s) => s.id === owner);
+  if (subtopic?.default_visualization?.some((e) => e.indicator_id === from)) {
+    reports.push({
+      collection: "subtopics",
+      legacy_id: owner,
+      change: `default_visualization indicator ${from} -> ${to}`,
+    });
+  }
+
+  const chartRow = rawIndicators.find((i) => i.id === INDICATOR_ADDS_CHART);
+  if (chartRow && !(chartRow.visualization_types ?? []).includes("chart")) {
+    reports.push({
+      collection: "indicators",
+      legacy_id: INDICATOR_ADDS_CHART,
+      change: "visualization_types += chart",
+    });
+  }
+
+  const rasterRow = rawIndicators.find((i) => i.id === INDICATOR_DROPS_RASTER_FUNCTION);
+  if (rasterRow?.resource.rasterFunction) {
+    reports.push({
+      collection: "indicators",
+      legacy_id: INDICATOR_DROPS_RASTER_FUNCTION,
+      change: "dropped resource.rasterFunction",
+    });
+  }
+
+  return reports;
+}

--- a/client/src/cms/seed/map-default-visualization.test.ts
+++ b/client/src/cms/seed/map-default-visualization.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { mapDefaultVisualization } from "./map-default-visualization";
-import { rawSubtopics, rawTopics, type RawDefaultVisualization } from "./source";
+import { rawIndicators, rawSubtopics, rawTopics, type RawDefaultVisualization } from "./source";
 
 const entry = (over: Partial<RawDefaultVisualization> = {}): RawDefaultVisualization => ({
   id: 1,
@@ -60,34 +60,17 @@ describe("mapDefaultVisualization", () => {
   });
 
   it("resolves every entry in the real source once fix 1 is applied", () => {
-    const ids = new Map(
-      // every indicator legacy_id that exists, plus none that do not
-      [
-        ...new Set([
-          146,
-          ...rawTopics.flatMap((t) => t.default_visualization ?? []).map((e) => e.indicator_id),
-        ]),
-      ].map((id) => [id, `uuid-${id}`] as const),
-    );
-    const topicSkips = rawTopics.flatMap(
-      (t) => mapDefaultVisualization(t.default_visualization, t.id, ids).skipped,
-    );
-    expect(topicSkips).toEqual([]);
+    const ids = new Map(rawIndicators.map((i) => [i.id, `uuid-${i.id}`] as const));
 
-    const subtopicIds = new Map(
-      [
-        ...new Set([
-          146,
-          ...rawSubtopics
-            .flatMap((s) => s.default_visualization ?? [])
-            .map((e) => e.indicator_id)
-            .filter((id) => id !== 55),
-        ]),
-      ].map((id) => [id, `uuid-${id}`] as const),
-    );
-    const subtopicSkips = rawSubtopics.flatMap(
-      (s) => mapDefaultVisualization(s.default_visualization, s.id, subtopicIds).skipped,
-    );
-    expect(subtopicSkips).toEqual([]);
+    const skips = [
+      ...rawTopics.flatMap(
+        (t) => mapDefaultVisualization(t.default_visualization, t.id, ids).skipped,
+      ),
+      ...rawSubtopics.flatMap(
+        (s) => mapDefaultVisualization(s.default_visualization, s.id, ids).skipped,
+      ),
+    ];
+
+    expect(skips).toEqual([]);
   });
 });

--- a/client/src/cms/seed/map-default-visualization.test.ts
+++ b/client/src/cms/seed/map-default-visualization.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { mapDefaultVisualization } from "./map-default-visualization";
+import { rawSubtopics, rawTopics, type RawDefaultVisualization } from "./source";
+
+const entry = (over: Partial<RawDefaultVisualization> = {}): RawDefaultVisualization => ({
+  id: 1,
+  indicator_id: 3,
+  type: "map",
+  x: 0,
+  y: 0,
+  w: 2,
+  h: 4,
+  ...over,
+});
+
+describe("mapDefaultVisualization", () => {
+  it("maps geometry verbatim and resolves the indicator to its uuid", () => {
+    const ids = new Map([[3, "uuid-3"]]);
+    const { entries, skipped } = mapDefaultVisualization([entry()], 1, ids);
+
+    expect(skipped).toEqual([]);
+    expect(entries).toEqual([{ indicator: "uuid-3", type: "map", x: 0, y: 0, w: 2, h: 4 }]);
+  });
+
+  it("leaves basemapId and opacity unset so field defaults apply", () => {
+    const { entries } = mapDefaultVisualization([entry()], 1, new Map([[3, "uuid-3"]]));
+    expect(entries[0]).not.toHaveProperty("basemapId");
+    expect(entries[0]).not.toHaveProperty("opacity");
+  });
+
+  it("applies fix 1 for subtopic 26 and keeps the original geometry", () => {
+    const ids = new Map([[146, "uuid-146"]]);
+    const { entries, skipped } = mapDefaultVisualization(
+      [entry({ id: 55, indicator_id: 55 })],
+      26,
+      ids,
+    );
+
+    expect(skipped).toEqual([]);
+    expect(entries).toEqual([{ indicator: "uuid-146", type: "map", x: 0, y: 0, w: 2, h: 4 }]);
+  });
+
+  it("skips an unresolvable indicator instead of throwing", () => {
+    const { entries, skipped } = mapDefaultVisualization(
+      [entry({ indicator_id: 999 })],
+      1,
+      new Map(),
+    );
+
+    expect(entries).toEqual([]);
+    expect(skipped).toEqual([999]);
+  });
+
+  it("returns an empty result for a row with no default_visualization", () => {
+    expect(mapDefaultVisualization(undefined, 1, new Map())).toEqual({
+      entries: [],
+      skipped: [],
+    });
+  });
+
+  it("resolves every entry in the real source once fix 1 is applied", () => {
+    const ids = new Map(
+      // every indicator legacy_id that exists, plus none that do not
+      [
+        ...new Set([
+          146,
+          ...rawTopics.flatMap((t) => t.default_visualization ?? []).map((e) => e.indicator_id),
+        ]),
+      ].map((id) => [id, `uuid-${id}`] as const),
+    );
+    const topicSkips = rawTopics.flatMap(
+      (t) => mapDefaultVisualization(t.default_visualization, t.id, ids).skipped,
+    );
+    expect(topicSkips).toEqual([]);
+
+    const subtopicIds = new Map(
+      [
+        ...new Set([
+          146,
+          ...rawSubtopics
+            .flatMap((s) => s.default_visualization ?? [])
+            .map((e) => e.indicator_id)
+            .filter((id) => id !== 55),
+        ]),
+      ].map((id) => [id, `uuid-${id}`] as const),
+    );
+    const subtopicSkips = rawSubtopics.flatMap(
+      (s) => mapDefaultVisualization(s.default_visualization, s.id, subtopicIds).skipped,
+    );
+    expect(subtopicSkips).toEqual([]);
+  });
+});

--- a/client/src/cms/seed/map-default-visualization.ts
+++ b/client/src/cms/seed/map-default-visualization.ts
@@ -1,0 +1,42 @@
+import type { Topic } from "@/payload-types";
+
+import { resolveFixedIndicatorId } from "./fixes";
+import type { RawDefaultVisualization } from "./source";
+
+export type DefaultVisualizationEntry = NonNullable<Topic["default_visualization"]>[number];
+
+/**
+ * Shared by Topics and Subtopics. `basemapId` and `opacity` are absent from the source, so
+ * they are left unset and the field defaults (`gray-vector`, `1`) apply. An indicator that
+ * cannot be resolved is collected in `skipped` rather than throwing, so one bad reference
+ * does not abort the seed.
+ */
+export function mapDefaultVisualization(
+  entries: RawDefaultVisualization[] | undefined,
+  ownerLegacyId: number,
+  indicatorIds: Map<number, string>,
+): { entries: DefaultVisualizationEntry[]; skipped: number[] } {
+  const mapped: DefaultVisualizationEntry[] = [];
+  const skipped: number[] = [];
+
+  for (const raw of entries ?? []) {
+    const legacyId = resolveFixedIndicatorId(ownerLegacyId, raw.indicator_id);
+    const indicator = indicatorIds.get(legacyId);
+
+    if (!indicator) {
+      skipped.push(legacyId);
+      continue;
+    }
+
+    mapped.push({
+      indicator,
+      type: raw.type as DefaultVisualizationEntry["type"],
+      x: raw.x,
+      y: raw.y,
+      w: raw.w,
+      h: raw.h,
+    });
+  }
+
+  return { entries: mapped, skipped };
+}

--- a/client/src/cms/seed/map-indicator.test.ts
+++ b/client/src/cms/seed/map-indicator.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+
+import { INDICATOR_ADDS_CHART, INDICATOR_DROPS_RASTER_FUNCTION } from "./fixes";
+import { mapIndicatorBase, mapIndicatorLocale, mapResource } from "./map-indicator";
+import { rawIndicators, rawSubtopics, type RawResource } from "./source";
+
+const subtopicIds = new Map(rawSubtopics.map((s) => [s.id, `uuid-sub-${s.id}`] as const));
+const byId = (id: number) => rawIndicators.find((i) => i.id === id)!;
+
+describe("mapResource block selection", () => {
+  it("uses resource.type verbatim as blockType for every one of the 164 rows", () => {
+    for (const row of rawIndicators) {
+      const [block] = mapResource(row.resource, row.id);
+      expect(block.blockType, `indicator ${row.id}`).toBe(row.resource.type);
+    }
+  });
+
+  it("returns exactly one block per indicator", () => {
+    for (const row of rawIndicators) {
+      expect(mapResource(row.resource, row.id), `indicator ${row.id}`).toHaveLength(1);
+    }
+  });
+
+  it("maps the two block types absent from the source data", () => {
+    const imageryTile: RawResource = {
+      type: "imagery-tile",
+      name: "Tiled",
+      url: "https://example.test/tiles",
+      rasterFunction: { functionName: "Colormap" },
+      legend: { type: "basic", items: [{ label: "A", color: "#FFFFFF" }] },
+    };
+    expect(mapResource(imageryTile, 900)[0]).toMatchObject({
+      blockType: "imagery-tile",
+      url: "https://example.test/tiles",
+    });
+
+    const webTile: RawResource = { type: "web-tile", name: "Web", url: "https://example.test/w" };
+    expect(mapResource(webTile, 901)[0]).toEqual({
+      blockType: "web-tile",
+      name: "Web",
+      url: "https://example.test/w",
+    });
+  });
+
+  it("throws on an unknown resource type", () => {
+    expect(() => mapResource({ type: "nope" }, 902)).toThrow(/unknown resource type/i);
+  });
+});
+
+describe("mapResource field selection", () => {
+  it("drops the inert layer_id on h3, imagery and component blocks", () => {
+    for (const row of rawIndicators) {
+      if (row.resource.type === "feature") continue;
+      expect(row.resource.layer_id, `indicator ${row.id}`).toBe("0");
+      expect(mapResource(row.resource, row.id)[0], `indicator ${row.id}`).not.toHaveProperty(
+        "layer_id",
+      );
+    }
+  });
+
+  it("keeps layer_id as a string on feature blocks", () => {
+    const block = mapResource(byId(5).resource, 5)[0];
+    expect(block).toHaveProperty("layer_id");
+    expect(typeof (block as { layer_id: string }).layer_id).toBe("string");
+  });
+
+  it("unwraps popupTemplate.content into the group", () => {
+    const block = mapResource(byId(5).resource, 5)[0] as {
+      popupTemplate?: { title?: string; fieldInfos?: { fieldName: string; label: string }[] };
+    };
+    expect(block.popupTemplate?.title).toBe("{NOMBCAP}");
+    expect(block.popupTemplate?.fieldInfos).toEqual([
+      { fieldName: "NAME_1", label: "State" },
+      { fieldName: "NAME_0", label: "Country" },
+    ]);
+    expect(block.popupTemplate).not.toHaveProperty("content");
+  });
+
+  it("keeps title-only popupTemplates and omits fieldInfos", () => {
+    const titleOnly = rawIndicators.find((i) => {
+      const pt = i.resource.popupTemplate as { title?: string; content?: unknown[] } | undefined;
+      return Boolean(pt?.title) && (pt?.content ?? []).length === 0;
+    })!;
+    const block = mapResource(titleOnly.resource, titleOnly.id)[0] as {
+      popupTemplate?: { title?: string; fieldInfos?: unknown };
+    };
+    expect(block.popupTemplate?.title).toBeTruthy();
+    expect(block.popupTemplate).not.toHaveProperty("fieldInfos");
+  });
+
+  it("maps the imagery legend with its type and all items", () => {
+    const imagery = rawIndicators.find((i) => i.resource.type === "imagery")!;
+    const block = mapResource(imagery.resource, imagery.id)[0] as {
+      legend: { type: string; items: { label: string; color: string }[] };
+    };
+    expect(block.legend.type).toBe("basic");
+    expect(block.legend.items.length).toBeGreaterThan(0);
+    for (const item of block.legend.items) {
+      expect(Object.keys(item).sort()).toEqual(["color", "label"]);
+    }
+  });
+
+  it("applies fix 3: drops rasterFunction from indicator 12's feature block", () => {
+    const row = byId(INDICATOR_DROPS_RASTER_FUNCTION);
+    expect(row.resource.rasterFunction).toBe("Forest_Cover_Change");
+    expect(mapResource(row.resource, row.id)[0]).not.toHaveProperty("rasterFunction");
+  });
+
+  it("satisfies each block's required fields on all 164 rows", () => {
+    for (const row of rawIndicators) {
+      const block = mapResource(row.resource, row.id)[0] as Record<string, unknown>;
+      const required: Record<string, string[]> = {
+        feature: ["url", "layer_id"],
+        imagery: ["url", "rasterFunction", "legend"],
+        "imagery-tile": ["url", "rasterFunction", "legend"],
+        "web-tile": ["url"],
+        h3: ["name", "column"],
+        component: ["name"],
+      };
+      for (const key of required[block.blockType as string]) {
+        expect(block[key], `indicator ${row.id} needs ${key}`).toBeDefined();
+      }
+    }
+  });
+});
+
+describe("mapIndicatorBase", () => {
+  it("resolves the subtopic and applies fix 2 to indicator 5", () => {
+    const data = mapIndicatorBase(byId(INDICATOR_ADDS_CHART), subtopicIds);
+    expect(data.subtopic).toBe(`uuid-sub-${byId(INDICATOR_ADDS_CHART).subtopic_id}`);
+    expect(data.visualization_types).toEqual(["map", "numeric", "chart"]);
+  });
+
+  it("maps all 164 rows with required fields present and order preserved", () => {
+    for (const row of rawIndicators) {
+      const data = mapIndicatorBase(row, subtopicIds);
+      expect(data.legacy_id, `indicator ${row.id}`).toBe(row.id);
+      expect(data.order, `indicator ${row.id}`).toBe(row.order);
+      expect(data.name.length, `indicator ${row.id}`).toBeGreaterThan(0);
+      expect(data.description_short.length, `indicator ${row.id}`).toBeGreaterThan(0);
+      expect(data.subtopic, `indicator ${row.id}`).toBeTruthy();
+    }
+    expect(rawIndicators).toHaveLength(164);
+  });
+
+  it("throws on an unresolvable subtopic", () => {
+    expect(() => mapIndicatorBase(byId(5), new Map())).toThrow(/subtopic/i);
+  });
+});
+
+describe("mapIndicatorLocale", () => {
+  it("carries only flat localized text, never blocks", () => {
+    for (const row of rawIndicators) {
+      for (const locale of ["es", "pt"] as const) {
+        const data = mapIndicatorLocale(row, locale) as Record<string, unknown>;
+        expect(data, `indicator ${row.id}`).not.toHaveProperty("resource");
+        expect(data, `indicator ${row.id}`).not.toHaveProperty("subtopic");
+        expect(data, `indicator ${row.id}`).not.toHaveProperty("legacy_id");
+        expect(data, `indicator ${row.id}`).not.toHaveProperty("visualization_types");
+        for (const key of Object.keys(data)) {
+          expect(["name", "unit", "description", "description_short"]).toContain(key);
+        }
+      }
+    }
+  });
+
+  it("supplies es and pt names for all 164 rows", () => {
+    for (const row of rawIndicators) {
+      expect(mapIndicatorLocale(row, "es").name, `indicator ${row.id}`).toBeTruthy();
+      expect(mapIndicatorLocale(row, "pt").name, `indicator ${row.id}`).toBeTruthy();
+    }
+  });
+
+  it("trims every mapped value in every locale (fix 4)", () => {
+    for (const row of rawIndicators) {
+      for (const locale of ["en", "es", "pt"] as const) {
+        const data =
+          locale === "en" ? mapIndicatorBase(row, subtopicIds) : mapIndicatorLocale(row, locale);
+        for (const [key, value] of Object.entries(data)) {
+          if (typeof value !== "string") continue;
+          expect(value, `indicator ${row.id} ${locale}.${key}`).toBe(value.trim());
+        }
+      }
+    }
+  });
+});

--- a/client/src/cms/seed/map-indicator.test.ts
+++ b/client/src/cms/seed/map-indicator.test.ts
@@ -1,8 +1,49 @@
+import type { Field } from "payload";
+
 import { describe, expect, it } from "vitest";
+
+import { RESOURCE_BLOCKS } from "@/cms/fields/resource";
 
 import { INDICATOR_ADDS_CHART, INDICATOR_DROPS_RASTER_FUNCTION } from "./fixes";
 import { mapIndicatorBase, mapIndicatorLocale, mapResource } from "./map-indicator";
 import { rawIndicators, rawSubtopics, type RawResource } from "./source";
+
+/**
+ * Dot-paths of every `required: true` field in a block's fields, recursing into `group`
+ * fields (whose subfields flatten into the same output object) but not into `array`/`blocks`
+ * fields (whose required subfields are per-row, not per-block, and are already exercised by
+ * the dedicated tests below — e.g. "unwraps popupTemplate", "maps the imagery legend").
+ *
+ * Derived from `RESOURCE_BLOCKS` (client/src/cms/fields/resource.ts) instead of hand-copied,
+ * so a `required: true` field added to any block is caught here automatically — the `as
+ * ResourceBlock` casts in map-indicator.ts otherwise defeat `tsc` on exactly this kind of miss.
+ */
+function requiredFieldPaths(fields: Field[], prefix = ""): string[] {
+  const paths: string[] = [];
+  for (const field of fields) {
+    if (!("name" in field) || typeof field.name !== "string") continue;
+    const path = prefix ? `${prefix}.${field.name}` : field.name;
+    if ("required" in field && field.required === true) paths.push(path);
+    if (field.type === "group") paths.push(...requiredFieldPaths(field.fields, path));
+  }
+  return paths;
+}
+
+function getByPath(block: Record<string, unknown>, path: string): unknown {
+  return path
+    .split(".")
+    .reduce<unknown>(
+      (value, segment) =>
+        value && typeof value === "object"
+          ? (value as Record<string, unknown>)[segment]
+          : undefined,
+      block,
+    );
+}
+
+const REQUIRED_FIELD_PATHS: Record<string, string[]> = Object.fromEntries(
+  RESOURCE_BLOCKS.map((block) => [block.slug, requiredFieldPaths(block.fields)]),
+);
 
 const subtopicIds = new Map(rawSubtopics.map((s) => [s.id, `uuid-sub-${s.id}`] as const));
 const byId = (id: number) => rawIndicators.find((i) => i.id === id)!;
@@ -113,23 +154,32 @@ describe("mapResource field selection", () => {
   it("satisfies each block's required fields on all 164 rows", () => {
     for (const row of rawIndicators) {
       const block = mapResource(row.resource, row.id)[0] as Record<string, unknown>;
-      const required: Record<string, string[]> = {
-        feature: ["url", "layer_id"],
-        imagery: ["url", "rasterFunction", "legend"],
-        "imagery-tile": ["url", "rasterFunction", "legend"],
-        "web-tile": ["url"],
-        h3: ["name", "column"],
-        component: ["name"],
-      };
-      for (const key of required[block.blockType as string]) {
-        expect(block[key], `indicator ${row.id} needs ${key}`).toBeDefined();
-        expect(block[key], `indicator ${row.id} ${key} must not be null`).not.toBeNull();
+      const required = REQUIRED_FIELD_PATHS[block.blockType as string] ?? [];
+      for (const path of required) {
+        const value = getByPath(block, path);
+        expect(value, `indicator ${row.id} needs ${path}`).toBeDefined();
+        expect(value, `indicator ${row.id} ${path} must not be null`).not.toBeNull();
       }
       if (block.blockType === "imagery" || block.blockType === "imagery-tile") {
         const legend = block.legend as { items: unknown[] };
         expect(legend.items.length, `indicator ${row.id} legend.items`).toBeGreaterThan(0);
       }
     }
+  });
+
+  it("derives at least the previously hand-copied required fields per block", () => {
+    // Guards the deriving helper itself: if RESOURCE_BLOCKS ever stopped exposing these as
+    // `required: true`, this documents what used to be asserted by hand.
+    expect(REQUIRED_FIELD_PATHS.feature).toEqual(expect.arrayContaining(["url", "layer_id"]));
+    expect(REQUIRED_FIELD_PATHS.imagery).toEqual(
+      expect.arrayContaining(["url", "rasterFunction", "legend.type", "legend.items"]),
+    );
+    expect(REQUIRED_FIELD_PATHS["imagery-tile"]).toEqual(
+      expect.arrayContaining(["url", "rasterFunction", "legend.type", "legend.items"]),
+    );
+    expect(REQUIRED_FIELD_PATHS["web-tile"]).toEqual(expect.arrayContaining(["url"]));
+    expect(REQUIRED_FIELD_PATHS.h3).toEqual(expect.arrayContaining(["name", "column"]));
+    expect(REQUIRED_FIELD_PATHS.component).toEqual(expect.arrayContaining(["name"]));
   });
 });
 

--- a/client/src/cms/seed/map-indicator.test.ts
+++ b/client/src/cms/seed/map-indicator.test.ts
@@ -29,9 +29,12 @@ describe("mapResource block selection", () => {
       rasterFunction: { functionName: "Colormap" },
       legend: { type: "basic", items: [{ label: "A", color: "#FFFFFF" }] },
     };
-    expect(mapResource(imageryTile, 900)[0]).toMatchObject({
+    expect(mapResource(imageryTile, 900)[0]).toEqual({
       blockType: "imagery-tile",
+      name: "Tiled",
       url: "https://example.test/tiles",
+      rasterFunction: { functionName: "Colormap" },
+      legend: { type: "basic", items: [{ label: "A", color: "#FFFFFF" }] },
     });
 
     const webTile: RawResource = { type: "web-tile", name: "Web", url: "https://example.test/w" };
@@ -58,10 +61,11 @@ describe("mapResource field selection", () => {
     }
   });
 
-  it("keeps layer_id as a string on feature blocks", () => {
-    const block = mapResource(byId(5).resource, 5)[0];
+  it("keeps layer_id as the source string on feature blocks", () => {
+    const row = byId(5);
+    const block = mapResource(row.resource, 5)[0];
     expect(block).toHaveProperty("layer_id");
-    expect(typeof (block as { layer_id: string }).layer_id).toBe("string");
+    expect((block as { layer_id: string }).layer_id).toBe(row.resource.layer_id);
   });
 
   it("unwraps popupTemplate.content into the group", () => {
@@ -119,6 +123,11 @@ describe("mapResource field selection", () => {
       };
       for (const key of required[block.blockType as string]) {
         expect(block[key], `indicator ${row.id} needs ${key}`).toBeDefined();
+        expect(block[key], `indicator ${row.id} ${key} must not be null`).not.toBeNull();
+      }
+      if (block.blockType === "imagery" || block.blockType === "imagery-tile") {
+        const legend = block.legend as { items: unknown[] };
+        expect(legend.items.length, `indicator ${row.id} legend.items`).toBeGreaterThan(0);
       }
     }
   });
@@ -181,6 +190,37 @@ describe("mapIndicatorLocale", () => {
           expect(value, `indicator ${row.id} ${locale}.${key}`).toBe(value.trim());
         }
       }
+
+      const block = mapResource(row.resource, row.id)[0] as Record<string, unknown>;
+
+      const popupTemplate = block.popupTemplate as
+        | { fieldInfos?: { fieldName: string; label: string }[] }
+        | undefined;
+      for (const field of popupTemplate?.fieldInfos ?? []) {
+        expect(field.fieldName, `indicator ${row.id} popupTemplate.fieldName`).toBe(
+          field.fieldName.trim(),
+        );
+        expect(field.label, `indicator ${row.id} popupTemplate.label`).toBe(field.label.trim());
+      }
+
+      const legend = block.legend as { items?: { label: string; color: string }[] } | undefined;
+      for (const item of legend?.items ?? []) {
+        expect(item.label, `indicator ${row.id} legend.label`).toBe(item.label.trim());
+        expect(item.color, `indicator ${row.id} legend.color`).toBe(item.color.trim());
+      }
     }
+  });
+
+  it("trims indicator 140's fieldName, fixing the broken ArcGIS field match", () => {
+    const row = byId(140);
+    expect(
+      (row.resource.popupTemplate as { content: { fieldInfos: { fieldName: string }[] }[] })
+        .content[0].fieldInfos[0].fieldName,
+    ).toBe("LENGTHm ");
+
+    const block = mapResource(row.resource, 140)[0] as {
+      popupTemplate?: { fieldInfos?: { fieldName: string; label: string }[] };
+    };
+    expect(block.popupTemplate?.fieldInfos?.[0].fieldName).toBe("LENGTHm");
   });
 });

--- a/client/src/cms/seed/map-indicator.ts
+++ b/client/src/cms/seed/map-indicator.ts
@@ -1,0 +1,194 @@
+import type { Indicator } from "@/payload-types";
+
+import { fixVisualizationTypes } from "./fixes";
+import { omitUndefined } from "./map-topic";
+import { json, localized, text, type Locale, type RawIndicator, type RawResource } from "./source";
+
+type ResourceBlock = Indicator["resource"][number];
+type FieldInfo = { fieldName: string; label: string };
+
+export type IndicatorBaseData = {
+  legacy_id: number;
+  order: number;
+  subtopic: string;
+  name: string;
+  description_short: string;
+  unit?: string;
+  description?: string;
+  visualization_types?: Indicator["visualization_types"];
+  resource: Indicator["resource"];
+};
+
+export type IndicatorLocaleData = {
+  name?: string;
+  unit?: string;
+  description?: string;
+  description_short?: string;
+};
+
+type RawPopupTemplate = {
+  title?: string;
+  content?: { type?: string; fieldInfos?: FieldInfo[] }[];
+};
+
+/**
+ * The source stores `{ title, content: [{ type: 'fields', fieldInfos }] }`. The wrapper is
+ * exactly one `type: 'fields'` element in all 45 rows that have content, and 10 rows are
+ * title-only, so it is dropped on write and rebuilt deterministically on read.
+ */
+function mapPopupTemplate(value: unknown) {
+  const raw = json<RawPopupTemplate>(value);
+  if (!raw) return undefined;
+
+  const fieldInfos = (raw.content ?? []).find((c) => c.type === "fields")?.fieldInfos;
+  const mapped = omitUndefined({
+    title: text(raw.title),
+    fieldInfos: fieldInfos?.length
+      ? fieldInfos.map((f) => ({ fieldName: f.fieldName, label: f.label }))
+      : undefined,
+  });
+
+  return Object.keys(mapped).length > 0 ? mapped : undefined;
+}
+
+function mapLegend(value: unknown) {
+  const raw = json<{ type?: string; items?: { label: string; color: string }[] }>(value);
+  if (!raw) throw new Error("imagery resource: missing legend");
+
+  return {
+    type: (raw.type ?? "basic") as "basic",
+    items: (raw.items ?? []).map((i) => ({ label: i.label, color: i.color })),
+  };
+}
+
+function requireText(value: unknown, message: string): string {
+  const result = text(value);
+  if (!result) throw new Error(message);
+  return result;
+}
+
+/**
+ * Block slugs are the source `resource.type` verbatim, so `blockType` *is* the resource
+ * type and phase 3 needs no mapping table.
+ *
+ * `layer_id` is dropped on every non-feature block: it is `'0'` on all 76 h3, 27 imagery
+ * and 1 component rows, an inert placeholder, and those blocks have no such field.
+ */
+export function mapResource(resource: RawResource, legacyId: number): Indicator["resource"] {
+  const name = text(resource.name);
+
+  switch (resource.type) {
+    // Fix 3 is structural: the feature block has no rasterFunction field, so indicator 12's
+    // bare-string `rasterFunction: 'Forest_Cover_Change'` is never carried across. See
+    // INDICATOR_DROPS_RASTER_FUNCTION in fixes.ts; asserted by the test suite.
+    case "feature": {
+      const block = {
+        blockType: "feature" as const,
+        url: requireText(resource.url, `indicator ${legacyId}: feature resource missing url`),
+        layer_id: text(resource.layer_id) ?? "0",
+        ...omitUndefined({
+          name,
+          popupTemplate: mapPopupTemplate(resource.popupTemplate),
+          query_numeric: json(resource.query_numeric),
+          query_table: json(resource.query_table),
+          query_chart: json(resource.query_chart),
+          query_ai: json(resource.query_ai),
+        }),
+      };
+      return [block as ResourceBlock];
+    }
+
+    case "imagery":
+    case "imagery-tile": {
+      return [
+        {
+          blockType: resource.type,
+          url: requireText(resource.url, `indicator ${legacyId}: imagery resource missing url`),
+          rasterFunction: json(resource.rasterFunction) ?? null,
+          legend: mapLegend(resource.legend),
+          ...omitUndefined({ name }),
+        } as ResourceBlock,
+      ];
+    }
+
+    case "web-tile": {
+      return [
+        {
+          blockType: "web-tile",
+          url: requireText(resource.url, `indicator ${legacyId}: web-tile resource missing url`),
+          ...omitUndefined({ name }),
+        } as ResourceBlock,
+      ];
+    }
+
+    case "h3": {
+      return [
+        {
+          blockType: "h3",
+          name: requireText(resource.name, `indicator ${legacyId}: h3 resource missing name`),
+          column: requireText(resource.column, `indicator ${legacyId}: h3 resource missing column`),
+          ...omitUndefined({ url: text(resource.url) }),
+        } as ResourceBlock,
+      ];
+    }
+
+    case "component": {
+      return [
+        {
+          blockType: "component",
+          name: requireText(
+            resource.name,
+            `indicator ${legacyId}: component resource missing name`,
+          ),
+          ...omitUndefined({ query_ai: json(resource.query_ai) }),
+        } as ResourceBlock,
+      ];
+    }
+
+    default:
+      throw new Error(`indicator ${legacyId}: unknown resource type ${String(resource.type)}`);
+  }
+}
+
+export function mapIndicatorBase(
+  row: RawIndicator,
+  subtopicIds: Map<number, string>,
+): IndicatorBaseData {
+  const name = localized(row, "name", "en");
+  if (!name) throw new Error(`indicator ${row.id}: missing name_en`);
+
+  const descriptionShort = localized(row, "description_short", "en");
+  if (!descriptionShort) throw new Error(`indicator ${row.id}: missing description_short_en`);
+
+  const subtopic = subtopicIds.get(row.subtopic_id);
+  if (!subtopic) {
+    throw new Error(`indicator ${row.id}: unresolvable subtopic ${row.subtopic_id}`);
+  }
+
+  const types = fixVisualizationTypes(row.id, row.visualization_types ?? []);
+
+  return {
+    legacy_id: row.id,
+    order: row.order,
+    subtopic,
+    name,
+    description_short: descriptionShort,
+    resource: mapResource(row.resource, row.id),
+    ...omitUndefined({
+      unit: localized(row, "unit", "en"),
+      description: localized(row, "description", "en"),
+      visualization_types: types.length
+        ? (types as NonNullable<Indicator["visualization_types"]>)
+        : undefined,
+    }),
+  };
+}
+
+export function mapIndicatorLocale(row: RawIndicator, locale: Locale): IndicatorLocaleData {
+  return omitUndefined({
+    name: localized(row, "name", locale),
+    unit: localized(row, "unit", locale),
+    description: localized(row, "description", locale),
+    description_short: localized(row, "description_short", locale),
+  });
+}

--- a/client/src/cms/seed/map-indicator.ts
+++ b/client/src/cms/seed/map-indicator.ts
@@ -36,7 +36,7 @@ type RawPopupTemplate = {
  * exactly one `type: 'fields'` element in all 45 rows that have content, and 10 rows are
  * title-only, so it is dropped on write and rebuilt deterministically on read.
  */
-function mapPopupTemplate(value: unknown) {
+function mapPopupTemplate(value: unknown, legacyId: number) {
   const raw = json<RawPopupTemplate>(value);
   if (!raw) return undefined;
 
@@ -44,20 +44,32 @@ function mapPopupTemplate(value: unknown) {
   const mapped = omitUndefined({
     title: text(raw.title),
     fieldInfos: fieldInfos?.length
-      ? fieldInfos.map((f) => ({ fieldName: f.fieldName, label: f.label }))
+      ? fieldInfos.map((f) => ({
+          fieldName: requireText(
+            f.fieldName,
+            `indicator ${legacyId}: popupTemplate fieldInfo missing fieldName`,
+          ),
+          label: requireText(
+            f.label,
+            `indicator ${legacyId}: popupTemplate fieldInfo missing label`,
+          ),
+        }))
       : undefined,
   });
 
   return Object.keys(mapped).length > 0 ? mapped : undefined;
 }
 
-function mapLegend(value: unknown) {
+function mapLegend(value: unknown, legacyId: number, blockType: string) {
   const raw = json<{ type?: string; items?: { label: string; color: string }[] }>(value);
-  if (!raw) throw new Error("imagery resource: missing legend");
+  if (!raw) throw new Error(`indicator ${legacyId}: ${blockType} resource missing legend`);
 
   return {
     type: (raw.type ?? "basic") as "basic",
-    items: (raw.items ?? []).map((i) => ({ label: i.label, color: i.color })),
+    items: (raw.items ?? []).map((i) => ({
+      label: requireText(i.label, `indicator ${legacyId}: legend item missing label`),
+      color: requireText(i.color, `indicator ${legacyId}: legend item missing color`),
+    })),
   };
 }
 
@@ -85,10 +97,13 @@ export function mapResource(resource: RawResource, legacyId: number): Indicator[
       const block = {
         blockType: "feature" as const,
         url: requireText(resource.url, `indicator ${legacyId}: feature resource missing url`),
-        layer_id: text(resource.layer_id) ?? "0",
+        layer_id: requireText(
+          resource.layer_id,
+          `indicator ${legacyId}: feature resource missing layer_id`,
+        ),
         ...omitUndefined({
           name,
-          popupTemplate: mapPopupTemplate(resource.popupTemplate),
+          popupTemplate: mapPopupTemplate(resource.popupTemplate, legacyId),
           query_numeric: json(resource.query_numeric),
           query_table: json(resource.query_table),
           query_chart: json(resource.query_chart),
@@ -100,12 +115,17 @@ export function mapResource(resource: RawResource, legacyId: number): Indicator[
 
     case "imagery":
     case "imagery-tile": {
+      const rasterFunction = json(resource.rasterFunction);
+      if (rasterFunction === undefined) {
+        throw new Error(`indicator ${legacyId}: ${resource.type} resource missing rasterFunction`);
+      }
+
       return [
         {
           blockType: resource.type,
           url: requireText(resource.url, `indicator ${legacyId}: imagery resource missing url`),
-          rasterFunction: json(resource.rasterFunction) ?? null,
-          legend: mapLegend(resource.legend),
+          rasterFunction,
+          legend: mapLegend(resource.legend, legacyId, resource.type),
           ...omitUndefined({ name }),
         } as ResourceBlock,
       ];

--- a/client/src/cms/seed/map-subtopic.test.ts
+++ b/client/src/cms/seed/map-subtopic.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { mapSubtopicBase, mapSubtopicLocale } from "./map-subtopic";
-import { rawSubtopics, rawTopics } from "./source";
+import { rawSubtopics, rawTopics, type RawSubtopic } from "./source";
 
 const topicIds = new Map(rawTopics.map((t) => [t.id, `uuid-topic-${t.id}`] as const));
 
@@ -38,6 +38,11 @@ describe("mapSubtopicBase", () => {
     const row = rawSubtopics[0];
     expect(() => mapSubtopicBase(row, new Map())).toThrow(/topic/i);
   });
+
+  it("throws when name_en is blank rather than writing a nameless subtopic", () => {
+    const row = { id: 999, topic_id: rawTopics[0].id, name_en: "" } as RawSubtopic;
+    expect(() => mapSubtopicBase(row, topicIds)).toThrow(/name_en/i);
+  });
 });
 
 describe("mapSubtopicLocale", () => {
@@ -59,5 +64,11 @@ describe("mapSubtopicLocale", () => {
     for (const row of rawSubtopics) {
       expect(mapSubtopicLocale(row, "es")).not.toHaveProperty("description");
     }
+  });
+
+  it("throws when the subtopic id has no translation entry, rather than dropping name", () => {
+    const row = { ...rawSubtopics[0], id: 999, name_en: "Untranslated" } as RawSubtopic;
+    expect(() => mapSubtopicLocale(row, "es")).toThrow(/999/);
+    expect(() => mapSubtopicLocale(row, "es")).toThrow(/translation/i);
   });
 });

--- a/client/src/cms/seed/map-subtopic.test.ts
+++ b/client/src/cms/seed/map-subtopic.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { mapSubtopicBase, mapSubtopicLocale } from "./map-subtopic";
+import { rawSubtopics, rawTopics } from "./source";
+
+const topicIds = new Map(rawTopics.map((t) => [t.id, `uuid-topic-${t.id}`] as const));
+
+describe("mapSubtopicBase", () => {
+  it("resolves the topic relationship and omits default_visualization", () => {
+    const row = rawSubtopics.find((s) => s.id === 26)!;
+    const data = mapSubtopicBase(row, topicIds);
+
+    expect(data.legacy_id).toBe(26);
+    expect(data.topic).toBe(`uuid-topic-${row.topic_id}`);
+    expect(data).not.toHaveProperty("default_visualization");
+  });
+
+  it("trims the untrimmed name on subtopic 3 (fix 4)", () => {
+    const row = rawSubtopics.find((s) => s.id === 3)!;
+    expect(row.name_en).toBe("Land Cover\n\n");
+    expect(mapSubtopicBase(row, topicIds).name).toBe("Land Cover");
+  });
+
+  it("resolves every topic_id for all 28 rows", () => {
+    for (const row of rawSubtopics) {
+      expect(mapSubtopicBase(row, topicIds).topic, `subtopic ${row.id}`).toBeTruthy();
+    }
+    expect(rawSubtopics).toHaveLength(28);
+  });
+
+  it("drops the image field, which no collection field accepts", () => {
+    for (const row of rawSubtopics) {
+      expect(mapSubtopicBase(row, topicIds)).not.toHaveProperty("image");
+    }
+  });
+
+  it("throws on an unresolvable topic rather than writing a dangling row", () => {
+    const row = rawSubtopics[0];
+    expect(() => mapSubtopicBase(row, new Map())).toThrow(/topic/i);
+  });
+});
+
+describe("mapSubtopicLocale", () => {
+  it("uses the translation table, since the source has no es or pt names", () => {
+    const row = rawSubtopics.find((s) => s.id === 26)!;
+    expect(row.name_es).toBe("");
+    expect(mapSubtopicLocale(row, "es").name).toBe("Infraestructura de Seguridad");
+    expect(mapSubtopicLocale(row, "pt").name).toBe("Infraestrutura de Segurança");
+  });
+
+  it("supplies a name for all 28 rows in both locales", () => {
+    for (const row of rawSubtopics) {
+      expect(mapSubtopicLocale(row, "es").name, `subtopic ${row.id}`).toBeTruthy();
+      expect(mapSubtopicLocale(row, "pt").name, `subtopic ${row.id}`).toBeTruthy();
+    }
+  });
+
+  it("omits description, which is empty in every locale on every row", () => {
+    for (const row of rawSubtopics) {
+      expect(mapSubtopicLocale(row, "es")).not.toHaveProperty("description");
+    }
+  });
+});

--- a/client/src/cms/seed/map-subtopic.ts
+++ b/client/src/cms/seed/map-subtopic.ts
@@ -1,0 +1,42 @@
+import { omitUndefined } from "./map-topic";
+import { localized, type Locale, type RawSubtopic } from "./source";
+import { SUBTOPIC_NAMES } from "./translations";
+
+export type SubtopicBaseData = {
+  legacy_id: number;
+  topic: string;
+  name: string;
+  description?: string;
+};
+
+export type SubtopicLocaleData = {
+  name?: string;
+  description?: string;
+};
+
+/**
+ * `image` exists on the source rows but on 0 of 28 with a value, and `Subtopics` has no
+ * such field, so it is dropped.
+ */
+export function mapSubtopicBase(row: RawSubtopic, topicIds: Map<number, string>): SubtopicBaseData {
+  const name = localized(row, "name", "en");
+  if (!name) throw new Error(`subtopic ${row.id}: missing name_en`);
+
+  const topic = topicIds.get(row.topic_id);
+  if (!topic) throw new Error(`subtopic ${row.id}: unresolvable topic ${row.topic_id}`);
+
+  return {
+    legacy_id: row.id,
+    topic,
+    name,
+    ...omitUndefined({ description: localized(row, "description", "en") }),
+  };
+}
+
+/** The source has no ES or PT subtopic names, so they come from the translation table. */
+export function mapSubtopicLocale(row: RawSubtopic, locale: Locale): SubtopicLocaleData {
+  return omitUndefined({
+    name: locale === "en" ? localized(row, "name", "en") : SUBTOPIC_NAMES[row.id]?.[locale],
+    description: localized(row, "description", locale),
+  });
+}

--- a/client/src/cms/seed/map-subtopic.ts
+++ b/client/src/cms/seed/map-subtopic.ts
@@ -33,10 +33,25 @@ export function mapSubtopicBase(row: RawSubtopic, topicIds: Map<number, string>)
   };
 }
 
-/** The source has no ES or PT subtopic names, so they come from the translation table. */
+/**
+ * The source has no ES or PT subtopic names, so they come from the translation table.
+ * A subtopic id missing from that table throws rather than silently dropping `name` —
+ * `Subtopics.name` is `required` and `localized`, so a missing name would otherwise
+ * surface as a generic Payload validation error instead of one that names the row.
+ */
 export function mapSubtopicLocale(row: RawSubtopic, locale: Locale): SubtopicLocaleData {
+  if (locale === "en") {
+    return omitUndefined({
+      name: localized(row, "name", "en"),
+      description: localized(row, "description", "en"),
+    });
+  }
+
+  const names = SUBTOPIC_NAMES[row.id];
+  if (!names) throw new Error(`subtopic ${row.id}: no ${locale} translation in SUBTOPIC_NAMES`);
+
   return omitUndefined({
-    name: locale === "en" ? localized(row, "name", "en") : SUBTOPIC_NAMES[row.id]?.[locale],
+    name: names[locale],
     description: localized(row, "description", locale),
   });
 }

--- a/client/src/cms/seed/map-topic.test.ts
+++ b/client/src/cms/seed/map-topic.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { mapTopicBase, mapTopicLocale } from "./map-topic";
+import { rawTopics } from "./source";
+
+describe("mapTopicBase", () => {
+  it("maps the en payload without default_visualization", () => {
+    const row = rawTopics.find((t) => t.id === 3)!;
+    const data = mapTopicBase(row);
+
+    expect(data.legacy_id).toBe(3);
+    expect(data.name).toBe(row.name_en);
+    expect(data).not.toHaveProperty("default_visualization");
+  });
+
+  it("produces a valid payload for all 9 rows", () => {
+    for (const row of rawTopics) {
+      const data = mapTopicBase(row);
+      expect(typeof data.legacy_id, `topic ${row.id}`).toBe("number");
+      expect(data.name.length, `topic ${row.id}`).toBeGreaterThan(0);
+      expect(data.name, `topic ${row.id}`).toBe(data.name.trim());
+    }
+    expect(rawTopics).toHaveLength(9);
+  });
+
+  it("keeps image as a path string on the 8 rows that have one", () => {
+    const withImage = rawTopics.filter((t) => mapTopicBase(t).image !== undefined);
+    expect(withImage).toHaveLength(8);
+  });
+});
+
+describe("mapTopicLocale", () => {
+  it("carries only localized text", () => {
+    const row = rawTopics.find((t) => t.id === 3)!;
+    expect(Object.keys(mapTopicLocale(row, "es")).sort()).toEqual(["description", "name"]);
+  });
+
+  it("supplies es and pt names for all 9 rows", () => {
+    for (const row of rawTopics) {
+      expect(mapTopicLocale(row, "es").name, `topic ${row.id}`).toBeTruthy();
+      expect(mapTopicLocale(row, "pt").name, `topic ${row.id}`).toBeTruthy();
+    }
+  });
+});

--- a/client/src/cms/seed/map-topic.test.ts
+++ b/client/src/cms/seed/map-topic.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { mapTopicBase, mapTopicLocale } from "./map-topic";
-import { rawTopics } from "./source";
+import { rawTopics, type RawTopic } from "./source";
 
 describe("mapTopicBase", () => {
   it("maps the en payload without default_visualization", () => {
@@ -11,6 +11,11 @@ describe("mapTopicBase", () => {
     expect(data.legacy_id).toBe(3);
     expect(data.name).toBe(row.name_en);
     expect(data).not.toHaveProperty("default_visualization");
+  });
+
+  it("throws when name_en is blank rather than writing a nameless topic", () => {
+    const row = { id: 999, name_en: "  " } as RawTopic;
+    expect(() => mapTopicBase(row)).toThrow(/name_en/i);
   });
 
   it("produces a valid payload for all 9 rows", () => {

--- a/client/src/cms/seed/map-topic.ts
+++ b/client/src/cms/seed/map-topic.ts
@@ -1,0 +1,43 @@
+import { localized, text, type Locale, type RawTopic } from "./source";
+
+export type TopicBaseData = {
+  legacy_id: number;
+  name: string;
+  description?: string;
+  image?: string;
+};
+
+export type TopicLocaleData = {
+  name?: string;
+  description?: string;
+};
+
+/**
+ * The `en` payload plus every non-localized field. `default_visualization` is deliberately
+ * omitted: it references indicators, which do not exist until pass 3, so pass 4 backfills it.
+ */
+export function mapTopicBase(row: RawTopic): TopicBaseData {
+  const name = localized(row, "name", "en");
+  if (!name) throw new Error(`topic ${row.id}: missing name_en`);
+
+  return {
+    legacy_id: row.id,
+    name,
+    ...omitUndefined({
+      description: localized(row, "description", "en"),
+      image: text(row.image),
+    }),
+  };
+}
+
+export function mapTopicLocale(row: RawTopic, locale: Locale): TopicLocaleData {
+  return omitUndefined({
+    name: localized(row, "name", locale),
+    description: localized(row, "description", locale),
+  });
+}
+
+/** Keeps `undefined` keys out of the payload so Payload does not clear existing values. */
+export function omitUndefined<T extends Record<string, unknown>>(value: T): Partial<T> {
+  return Object.fromEntries(Object.entries(value).filter(([, v]) => v !== undefined)) as Partial<T>;
+}

--- a/client/src/cms/seed/source.test.ts
+++ b/client/src/cms/seed/source.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { isBlank, json, localized, text } from "./source";
+import { isBlank, json, localized, LOCALES, text, TRANSLATION_LOCALES } from "./source";
+
+describe("LOCALES and TRANSLATION_LOCALES", () => {
+  it("keeps the exact locale order the seed write sequence depends on", () => {
+    // TRANSLATION_LOCALES drives the create-then-update write order in scripts/seed-catalogue.ts
+    // (en create, then es, then pt updates). A silent reorder here would invert that sequence
+    // with no other test catching it.
+    expect(LOCALES).toEqual(["en", "es", "pt"]);
+    expect(TRANSLATION_LOCALES).toEqual(["es", "pt"]);
+  });
+});
 
 describe("isBlank", () => {
   it("treats the source's placeholder blanks as absent", () => {

--- a/client/src/cms/seed/source.test.ts
+++ b/client/src/cms/seed/source.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { isBlank, json, localized, text } from "./source";
+
+describe("isBlank", () => {
+  it("treats the source's placeholder blanks as absent", () => {
+    expect(isBlank("")).toBe(true);
+    expect(isBlank("   ")).toBe(true);
+    expect(isBlank("\n\n")).toBe(true);
+    expect(isBlank([])).toBe(true);
+    expect(isBlank({})).toBe(true);
+    expect(isBlank(null)).toBe(true);
+    expect(isBlank(undefined)).toBe(true);
+  });
+
+  it("preserves falsy values that are real data", () => {
+    expect(isBlank(0)).toBe(false);
+    expect(isBlank(false)).toBe(false);
+    expect(isBlank("0")).toBe(false);
+    expect(isBlank([0])).toBe(false);
+    expect(isBlank({ a: 1 })).toBe(false);
+  });
+});
+
+describe("text", () => {
+  it("returns undefined for blanks and trims everything else (fix 4)", () => {
+    expect(text("")).toBeUndefined();
+    expect(text("   ")).toBeUndefined();
+    expect(text("Land Cover\n\n")).toBe("Land Cover");
+    expect(text("Corn Production ")).toBe("Corn Production");
+    expect(text(" Zonas de Influencia Costera")).toBe("Zonas de Influencia Costera");
+    expect(text("\nInstalaciones de Generación Eléctrica")).toBe(
+      "Instalaciones de Generación Eléctrica",
+    );
+  });
+});
+
+describe("json", () => {
+  it("passes non-blank structures through untouched and drops blanks", () => {
+    const query = { where: "1=1", outFields: ["*"] };
+    expect(json(query)).toBe(query);
+    expect(json("")).toBeUndefined();
+    expect(json([])).toBeUndefined();
+  });
+});
+
+describe("localized", () => {
+  it("reads the locale-suffixed key and trims it", () => {
+    const row = { name_en: "Health ", name_es: "Salud", name_pt: "" };
+    expect(localized(row, "name", "en")).toBe("Health");
+    expect(localized(row, "name", "es")).toBe("Salud");
+    expect(localized(row, "name", "pt")).toBeUndefined();
+  });
+});

--- a/client/src/cms/seed/source.ts
+++ b/client/src/cms/seed/source.ts
@@ -1,0 +1,95 @@
+import INDICATORS from "@/../datum/indicators.json";
+import SUBTOPICS from "@/../datum/subtopics.json";
+import TOPICS from "@/../datum/topics.json";
+
+export type Locale = "en" | "es" | "pt";
+
+export const LOCALES = ["en", "es", "pt"] as const satisfies readonly Locale[];
+
+/** Locales written by an `update` after the `en` create. */
+export const TRANSLATION_LOCALES = ["es", "pt"] as const satisfies readonly Locale[];
+
+/**
+ * The source JSON is a flat uniform record: every row carries every key, and absent
+ * values are placeholders (`""`, `[]`) rather than missing keys. `0` and `false` are real
+ * data and must survive.
+ */
+export function isBlank(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === "string") return value.trim() === "";
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === "object") return Object.keys(value as object).length === 0;
+  return false;
+}
+
+/**
+ * Fix 4: trims every text value on the way in. 75 source values carry leading or trailing
+ * whitespace — 14 in names, 61 in markdown descriptions. Applied uniformly rather than to
+ * an allowlist so it keeps covering rows edited later.
+ */
+export function text(value: unknown): string | undefined {
+  if (isBlank(value)) return undefined;
+  return String(value).trim();
+}
+
+export function json<T>(value: unknown): T | undefined {
+  if (isBlank(value)) return undefined;
+  return value as T;
+}
+
+export function localized(
+  row: Record<string, unknown>,
+  field: string,
+  locale: Locale,
+): string | undefined {
+  return text(row[`${field}_${locale}`]);
+}
+
+export type RawDefaultVisualization = {
+  id: number;
+  indicator_id: number;
+  type: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+};
+
+export type RawResource = {
+  name?: string;
+  type?: string;
+  url?: string;
+  layer_id?: string;
+  column?: unknown;
+  rasterFunction?: unknown;
+  legend?: unknown;
+  query_numeric?: unknown;
+  query_table?: unknown;
+  query_chart?: unknown;
+  query_ai?: unknown;
+  popupTemplate?: unknown;
+};
+
+export type RawTopic = {
+  id: number;
+  image?: string;
+  default_visualization?: RawDefaultVisualization[];
+} & Record<string, unknown>;
+
+export type RawSubtopic = {
+  id: number;
+  topic_id: number;
+  default_visualization?: RawDefaultVisualization[];
+} & Record<string, unknown>;
+
+export type RawIndicator = {
+  id: number;
+  subtopic_id: number;
+  order: number;
+  visualization_types?: string[];
+  resource: RawResource;
+} & Record<string, unknown>;
+
+export const rawTopics = TOPICS as unknown as RawTopic[];
+export const rawSubtopics = SUBTOPICS as unknown as RawSubtopic[];
+export const rawIndicators = INDICATORS as unknown as RawIndicator[];

--- a/client/src/cms/seed/translations.test.ts
+++ b/client/src/cms/seed/translations.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { rawSubtopics } from "./source";
+import { SUBTOPIC_NAMES } from "./translations";
+
+describe("SUBTOPIC_NAMES", () => {
+  it("covers every subtopic legacy_id exactly, with no extras", () => {
+    expect(
+      Object.keys(SUBTOPIC_NAMES)
+        .map(Number)
+        .sort((a, b) => a - b),
+    ).toEqual(rawSubtopics.map((s) => s.id).sort((a, b) => a - b));
+  });
+
+  it("supplies a non-empty, trimmed es and pt name for all 28", () => {
+    expect(Object.keys(SUBTOPIC_NAMES)).toHaveLength(28);
+    for (const [id, names] of Object.entries(SUBTOPIC_NAMES)) {
+      expect(names.es.trim(), `es for ${id}`).toBe(names.es);
+      expect(names.pt.trim(), `pt for ${id}`).toBe(names.pt);
+      expect(names.es.length, `es for ${id}`).toBeGreaterThan(0);
+      expect(names.pt.length, `pt for ${id}`).toBeGreaterThan(0);
+    }
+  });
+
+  it("leaves the undefined ACU acronym untranslated and expands IDB to BID", () => {
+    expect(SUBTOPIC_NAMES[0]).toEqual({ es: "ACU", pt: "ACU" });
+    expect(SUBTOPIC_NAMES[33]).toEqual({ es: "BID", pt: "BID" });
+  });
+});

--- a/client/src/cms/seed/translations.ts
+++ b/client/src/cms/seed/translations.ts
@@ -1,0 +1,47 @@
+/**
+ * ES and PT subtopic names. The source JSON has English only for all 28 rows, and
+ * `Subtopics.name` is `required`, so the ES/PT admin tabs cannot be saved without these.
+ *
+ * `0` "ACU" is an undefined project acronym — its only other trace in the codebase is the
+ * `ACU_KnowledgeDB` ArcGIS service in `constants/datasets.ts` — so it is left untranslated
+ * in all three locales. `33` "IDB" becomes "BID" (Banco Interamericano de Desarrollo /
+ * de Desenvolvimento), the standard acronym in both languages.
+ *
+ * Editors can change any of these in the CMS.
+ */
+export const SUBTOPIC_NAMES: Record<number, { es: string; pt: string }> = {
+  0: { es: "ACU", pt: "ACU" },
+  1: { es: "Geografía Física", pt: "Geografia Física" },
+  2: { es: "Áreas Protegidas y de Conservación", pt: "Áreas Protegidas e de Conservação" },
+  3: { es: "Cobertura del Suelo", pt: "Cobertura do Solo" },
+  4: { es: "Dinámica Forestal y Carbono", pt: "Dinâmica Florestal e Carbono" },
+  5: { es: "Ecosistemas Naturales", pt: "Ecossistemas Naturais" },
+  6: { es: "Ecosistemas Modificados", pt: "Ecossistemas Modificados" },
+  7: { es: "Biodiversidad y Conservación", pt: "Biodiversidade e Conservação" },
+  8: { es: "Patrones Climáticos", pt: "Padrões Climáticos" },
+  10: { es: "Demografía", pt: "Demografia" },
+  11: { es: "Desarrollo Social", pt: "Desenvolvimento Social" },
+  12: { es: "Indígena y Cultural", pt: "Indígena e Cultural" },
+  13: { es: "Panorama Económico", pt: "Panorama Econômico" },
+  14: { es: "Industrias Extractivas", pt: "Indústrias Extrativas" },
+  15: {
+    es: "Agricultura - Cultivos de Seguridad Alimentaria",
+    pt: "Agricultura - Culturas de Segurança Alimentar",
+  },
+  16: {
+    es: "Agricultura - Cultivos de Exportación",
+    pt: "Agricultura - Culturas de Exportação",
+  },
+  18: { es: "Bioeconomía", pt: "Bioeconomia" },
+  19: { es: "Turismo y Hostelería", pt: "Turismo e Hotelaria" },
+  21: { es: "Salud", pt: "Saúde" },
+  22: { es: "Educación", pt: "Educação" },
+  23: { es: "Transporte", pt: "Transporte" },
+  24: { es: "Servicios Públicos", pt: "Serviços Públicos" },
+  25: { es: "Comunicación", pt: "Comunicação" },
+  26: { es: "Infraestructura de Seguridad", pt: "Infraestrutura de Segurança" },
+  27: { es: "Desarrollo Urbano", pt: "Desenvolvimento Urbano" },
+  28: { es: "Riesgos Ambientales", pt: "Riscos Ambientais" },
+  29: { es: "Riesgos Sociales y de Seguridad", pt: "Riscos Sociais e de Segurança" },
+  33: { es: "BID", pt: "BID" },
+};


### PR DESCRIPTION
## Summary

- Seeds the 201 rows of `client/datum/{topics,subtopics,indicators}.json` into the phase-1 CMS collections as **published**, multi-locale documents, via an idempotent `pnpm seed:catalogue`. Pure mappers live in `client/src/cms/seed/`; every side effect (arg parsing, `getPayload`, one wrapping transaction, four ordered passes, reporting) lives in `client/scripts/seed-catalogue.ts`. Writes go through the Local API, so drafts, the `_v` tables, the 6-block polymorphic `resource` field, field validation and the `beforeChange` hooks all work.
- Adds `pnpm verify:catalogue` — a read-only auditor (33 assertions) that derives its expectations from the source JSON and asserts publish status, locale coverage, the `default_visualization` backfill, and `legacy_id` set-equality in both directions.
- Applies four documented source-data fixes, and repairs one genuine pre-existing bug: indicator 140 carried `fieldName: "LENGTHm "` with a trailing space, which ArcGIS cannot match to a layer field — that popup row was rendering blank.

## Test plan

- [ ] `cd client && pnpm test` — 290 passing / 33 files
- [ ] `cd client && pnpm check-types && pnpm lint` — clean; 10 pre-existing `src/components/map/**` warnings only
- [ ] `cd client && pnpm verify:catalogue` — 33/33 PASS against a seeded database
- [ ] `cd client && pnpm seed:catalogue --dry-run` on an empty database — expect three `⚙ fix` lines, `+9/+28/+164`, backfill on 36, `↩ dry run — transaction rolled back`, no `⚠ skipped`
- [ ] Real run on the same database — expect `+created`, **not** `○skipped` (this is the rollback proof), ending `✅ committed`
- [ ] Re-run — expect `○9/○28/○164`, `+0` created, backfill on 0
- [ ] Confirm in `/admin` that Topics / Subtopics / Indicators all read **Published**, and that the Español and Português tabs show translated subtopic names
- [ ] Spot-check `--overwrite --yes` against a throwaway database, and confirm `--overwrite` alone refuses with a non-zero exit
- [ ] Confirm CI's `payload migrate` step passes

## Follow-ups (not in scope here)

- Drop `required`/`localized` from the two `label` fields in `cms/fields/resource.ts` so blocks needn't be re-sent per locale — needs a migration.
- Add `push: false` to `postgresAdapter`.
- Make `upsert`/`seed` exportable so the four-pass shell is unit-testable; it currently runs `main()` at module scope, so only `verify:catalogue` covers pass ordering.
- Add an audit counting es/pt block labels identical to their `en` counterpart, as a translator worklist.
